### PR TITLE
feat: add analytics and preview utilities

### DIFF
--- a/apps/website/src/lib/analytics.ts
+++ b/apps/website/src/lib/analytics.ts
@@ -1,0 +1,22 @@
+export interface EventPayload {
+  [key: string]: any;
+}
+
+/**
+ * Send an analytics event.
+ * Falls back to console logging when no analytics provider is loaded.
+ */
+export function trackEvent(name: string, payload: EventPayload = {}): void {
+  if (typeof window !== 'undefined' && (window as any).gtag) {
+    (window as any).gtag('event', name, payload);
+  } else {
+    console.debug('[analytics]', name, payload);
+  }
+}
+
+/**
+ * Track a standard page view.
+ */
+export function trackPageView(url: string): void {
+  trackEvent('page_view', { url });
+}

--- a/apps/website/src/lib/index.ts
+++ b/apps/website/src/lib/index.ts
@@ -1,0 +1,4 @@
+export * from './analytics';
+export * from './preview';
+export * from './seo';
+export * from './content/adapter';

--- a/apps/website/src/lib/preview.ts
+++ b/apps/website/src/lib/preview.ts
@@ -1,0 +1,22 @@
+/**
+ * Get the draft token from environment variables.
+ */
+export function getDraftToken(): string | undefined {
+  // Astro exposes public env vars on import.meta.env
+  return import.meta.env.PUBLIC_DRAFT_TOKEN as string | undefined;
+}
+
+/**
+ * Check if preview mode is enabled for a given URL.
+ * If no URL is passed, the current window location is used when available.
+ */
+export function isPreviewMode(url?: URL): boolean {
+  try {
+    const target = url ?? (typeof window !== 'undefined' ? new URL(window.location.href) : undefined);
+    if (!target) return false;
+    const token = target.searchParams.get('preview');
+    return Boolean(token && token === getDraftToken());
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add basic analytics helpers for event and page view tracking
- add preview mode helpers for draft token detection
- expose utilities through website lib index

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a1ffca63ac833187f97b8afc865bb5