### PR TITLE
feat: add insights preview block to home page

### DIFF
--- a/apps/website/src/content/pages/home.json
+++ b/apps/website/src/content/pages/home.json
@@ -248,6 +248,32 @@
       }
     },
     {
+      "id": "insights-preview",
+      "type": "InsightsPreview",
+      "props": {
+        "heading": "Insights Preview",
+        "description": "Explore our latest thinking on leadership and talent.",
+        "columns": "3",
+        "items": [
+          {
+            "title": "Placeholder Insight One",
+            "description": "Coming soon: in-depth analysis and perspectives.",
+            "href": "/insights/placeholder-one"
+          },
+          {
+            "title": "Placeholder Insight Two",
+            "description": "Insights on executive search and leadership hiring.",
+            "href": "/insights/placeholder-two"
+          },
+          {
+            "title": "Placeholder Insight Three",
+            "description": "Thought leadership articles coming shortly.",
+            "href": "/insights/placeholder-three"
+          }
+        ]
+      }
+    },
+    {
       "id": "partner-logos",
       "type": "Logos",
       "props": {


### PR DESCRIPTION
## Summary
- add InsightsPreview block to home page content with placeholder items linking to future insights articles

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68a1ffdb9e888331a7ee78f9dfeb18e6