### PR TITLE
feat: warn on multiple h1 headings

### DIFF
--- a/apps/website/src/components/ui/Heading.astro
+++ b/apps/website/src/components/ui/Heading.astro
@@ -1,15 +1,36 @@
 ---
+/**
+ * Heading component.
+ *
+ * Tracks if an `<h1>` has already been rendered on the page. If another
+ * `h1` is requested, the component logs a warning and renders an `h2`
+ * instead to avoid multiple primary headings.
+ */
 export interface Props {
   level: 1 | 2 | 3 | 4 | 5 | 6;
   class?: string;
 }
 
-const { level, class: className = '' } = Astro.props;
+// Module-level flag to track if an H1 has been rendered.
+let hasRenderedH1 = false;
+
+let { level, class: className = '' } = Astro.props;
+
+if (level === 1) {
+  if (hasRenderedH1) {
+    console.warn(
+      'Heading.astro: Multiple <h1> elements detected. Rendering as <h2> instead.'
+    );
+    level = 2;
+  } else {
+    hasRenderedH1 = true;
+  }
+}
 
 const baseClasses = 'font-semibold text-gray-900';
 const levelClasses: Record<number, string> = {
   1: 'text-4xl md:text-5xl lg:text-6xl leading-tight',
-  2: 'text-3xl md:text-4xl lg:text-5xl leading-tight', 
+  2: 'text-3xl md:text-4xl lg:text-5xl leading-tight',
   3: 'text-2xl md:text-3xl leading-tight',
   4: 'text-xl md:text-2xl leading-tight',
   5: 'text-lg md:text-xl leading-tight',


### PR DESCRIPTION
## Summary
- track if an `<h1>` has already been rendered in `Heading.astro`
- warn and downgrade to `<h2>` when a second `<h1>` is requested
- document single-h1 behavior in component comments

## Testing
- `npm test` *(fails: Missing script "test" in workspace website and content-bridge)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ffddb5d8833197ebc1f207cc7814