### PR TITLE
feat: add dynamic page loader

### DIFF
--- a/apps/website/src/pages/[slug].astro
+++ b/apps/website/src/pages/[slug].astro
@@ -1,0 +1,18 @@
+---
+import PageLayout from '../layouts/PageLayout.astro';
+import { loadPageBySlug } from '../lib/content/adapter';
+
+// Astro provides params as possibly undefined; cast to string for type safety
+const slug = Astro.params.slug as string;
+const page = await loadPageBySlug(slug);
+
+if (!page) {
+  return new Response(null, {
+    status: 404,
+    statusText: 'Page not found',
+  });
+}
+---
+
+<PageLayout page={page} />
+


### PR DESCRIPTION
## Summary
- handle dynamic page slugs to render page content

## Testing
- `npm test` *(fails: Missing script "test" for workspace)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a201a0f98883318198ebbbfa5e6189