### PR TITLE
feat: add service and resource pages

### DIFF
--- a/apps/website/src/content/pages/career-transition.json
+++ b/apps/website/src/content/pages/career-transition.json
@@ -1,0 +1,43 @@
+{
+  "slug": "career-transition",
+  "title": "Career Transition & Outplacement",
+  "status": "published",
+  "seo": {
+    "title": "Career Transition & Outplacement - Networkk",
+    "description": "Support your workforce through change with tailored transition programs.",
+    "canonical": "https://networkk.com/career-transition/",
+    "noindex": false,
+    "keywords": ["outplacement", "career coaching", "transition support"]
+  },
+  "blocks": [
+    {
+      "id": "hero-career-transition",
+      "type": "Hero",
+      "props": {
+        "title": "Support Your Workforce in Transition",
+        "subtitle": "Career Transition & Outplacement",
+        "description": "Structured programs that guide employees to new opportunities while protecting employer brand.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Plan a Transition Program",
+        "description": "Learn how we can assist with compassionate workforce transitions.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Request Consultation",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/careers.json
+++ b/apps/website/src/content/pages/careers.json
@@ -1,0 +1,43 @@
+{
+  "slug": "careers",
+  "title": "Careers at Networkk",
+  "status": "published",
+  "seo": {
+    "title": "Careers at Networkk",
+    "description": "Join our team and help shape the future of leadership.",
+    "canonical": "https://networkk.com/careers/",
+    "noindex": false,
+    "keywords": ["careers", "jobs", "networkk team"]
+  },
+  "blocks": [
+    {
+      "id": "hero-careers",
+      "type": "Hero",
+      "props": {
+        "title": "Join Our Team",
+        "subtitle": "Careers at Networkk",
+        "description": "Explore opportunities to grow your career with us.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Apply Now",
+        "description": "Interested in working with Networkk? Let's connect.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Contact HR",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/client-success-stories.json
+++ b/apps/website/src/content/pages/client-success-stories.json
@@ -1,0 +1,43 @@
+{
+  "slug": "client-success-stories",
+  "title": "Client Success Stories",
+  "status": "published",
+  "seo": {
+    "title": "Client Success Stories - Networkk",
+    "description": "Discover how our partnerships deliver measurable hiring success.",
+    "canonical": "https://networkk.com/client-success-stories/",
+    "noindex": false,
+    "keywords": ["case studies", "client success", "recruitment results"]
+  },
+  "blocks": [
+    {
+      "id": "hero-client-success",
+      "type": "Hero",
+      "props": {
+        "title": "See How We've Delivered Success",
+        "subtitle": "Client Success Stories",
+        "description": "Real-world examples of transformative leadership hires.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Work with Networkk for Your Next Hire",
+        "description": "Let's discuss how we can support your leadership needs.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Contact Us",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/diversity-inclusion.json
+++ b/apps/website/src/content/pages/diversity-inclusion.json
@@ -1,0 +1,43 @@
+{
+  "slug": "diversity-inclusion",
+  "title": "Diversity & Inclusion Consulting",
+  "status": "published",
+  "seo": {
+    "title": "Diversity & Inclusion Consulting - Networkk",
+    "description": "Build a diverse, inclusive workforce with strategic D&I programs.",
+    "canonical": "https://networkk.com/diversity-inclusion/",
+    "noindex": false,
+    "keywords": ["diversity", "inclusion", "DEI consulting"]
+  },
+  "blocks": [
+    {
+      "id": "hero-diversity-inclusion",
+      "type": "Hero",
+      "props": {
+        "title": "Build a Diverse, Inclusive Workforce",
+        "subtitle": "Diversity & Inclusion Consulting",
+        "description": "Inclusive strategies that drive innovation and performance.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Start Your D&I Journey",
+        "description": "Partner with us to embed inclusion across your organization.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Request Consultation",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/executive-search.json
+++ b/apps/website/src/content/pages/executive-search.json
@@ -1,0 +1,43 @@
+{
+  "slug": "executive-search",
+  "title": "Executive Search",
+  "status": "published",
+  "seo": {
+    "title": "Executive Search - Networkk",
+    "description": "Start your executive search with a trusted partner focused on confidentiality and results.",
+    "canonical": "https://networkk.com/executive-search/",
+    "noindex": false,
+    "keywords": ["executive search", "c-suite hiring", "leadership recruitment"]
+  },
+  "blocks": [
+    {
+      "id": "hero-executive-search",
+      "type": "Hero",
+      "props": {
+        "title": "Start Your Executive Search",
+        "subtitle": "Find transformative leaders",
+        "description": "We identify and secure top-tier executives who drive strategic growth.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Request a Search Consultation",
+        "description": "Connect with our team to begin your executive search journey.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Request Consultation",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/home.json
+++ b/apps/website/src/content/pages/home.json
@@ -25,7 +25,7 @@
         "ctas": [
           {
             "label": "Explore Our Services",
-            "href": "/services/executive-search",
+            "href": "/executive-search",
             "variant": "primary"
           },
           {
@@ -52,28 +52,28 @@
             "title": "Executive Search",
             "description": "Find C-suite and senior leadership talent who align with your vision and drive transformational growth through proven methodologies.",
             "icon": "🎯",
-            "href": "/services/executive-search",
+            "href": "/executive-search",
             "image": "https://images.pexels.com/photos/3184394/pexels-photo-3184394.jpeg?auto=compress&cs=tinysrgb&w=600&h=400&fit=crop"
           },
           {
             "title": "Leadership Hiring",
             "description": "Strategic recruitment for directors, VPs, and emerging leaders who will shape your organization's future and cultural evolution.",
             "icon": "👥",
-            "href": "/services/leadership-hiring",
+            "href": "/leadership-hiring",
             "image": "https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=600&h=400&fit=crop"
           },
           {
             "title": "Talent Advisory",
             "description": "Strategic guidance on leadership development, succession planning, and organizational design for sustainable competitive advantage.",
             "icon": "💡",
-            "href": "/services/talent-advisory",
+            "href": "/talent-advisory",
             "image": "https://images.pexels.com/photos/3184419/pexels-photo-3184419.jpeg?auto=compress&cs=tinysrgb&w=600&h=400&fit=crop"
           },
           {
             "title": "D&I Consulting",
             "description": "Build diverse, inclusive leadership teams that reflect your values, drive innovation, and create lasting organizational change.",
             "icon": "🌟",
-            "href": "/services/diversity-inclusion",
+            "href": "/diversity-inclusion",
             "image": "https://images.pexels.com/photos/3184357/pexels-photo-3184357.jpeg?auto=compress&cs=tinysrgb&w=600&h=400&fit=crop"
           }
         ]

--- a/apps/website/src/content/pages/industries.json
+++ b/apps/website/src/content/pages/industries.json
@@ -1,0 +1,43 @@
+{
+  "slug": "industries",
+  "title": "Industries",
+  "status": "published",
+  "seo": {
+    "title": "Industries We Serve - Networkk",
+    "description": "Explore the industry sectors where we deliver leadership talent.",
+    "canonical": "https://networkk.com/industries/",
+    "noindex": false,
+    "keywords": ["industries", "sector expertise", "market focus"]
+  },
+  "blocks": [
+    {
+      "id": "hero-industries",
+      "type": "Hero",
+      "props": {
+        "title": "Explore Industries We Serve",
+        "subtitle": "Industry Expertise",
+        "description": "From technology to healthcare, we partner across diverse sectors.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Talk to an Industry Specialist",
+        "description": "Connect with our team for sector-specific insights.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Contact Us",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/insights.json
+++ b/apps/website/src/content/pages/insights.json
@@ -1,0 +1,43 @@
+{
+  "slug": "insights",
+  "title": "Insights & Resources",
+  "status": "published",
+  "seo": {
+    "title": "Insights & Resources - Networkk",
+    "description": "Stay ahead with expert articles, reports and guides.",
+    "canonical": "https://networkk.com/insights/",
+    "noindex": false,
+    "keywords": ["insights", "resources", "leadership articles"]
+  },
+  "blocks": [
+    {
+      "id": "hero-insights",
+      "type": "Hero",
+      "props": {
+        "title": "Stay Ahead with Expert Insights",
+        "subtitle": "Insights & Resources",
+        "description": "Articles, guides and research to inform your talent strategy.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Subscribe for Updates",
+        "description": "Get the latest insights delivered to your inbox.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Subscribe",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/leadership-hiring.json
+++ b/apps/website/src/content/pages/leadership-hiring.json
@@ -1,0 +1,43 @@
+{
+  "slug": "leadership-hiring",
+  "title": "Leadership Hiring",
+  "status": "published",
+  "seo": {
+    "title": "Leadership Hiring - Networkk",
+    "description": "Find your next generation of leaders across industries and functions.",
+    "canonical": "https://networkk.com/leadership-hiring/",
+    "noindex": false,
+    "keywords": ["leadership hiring", "senior recruitment", "talent acquisition"]
+  },
+  "blocks": [
+    {
+      "id": "hero-leadership-hiring",
+      "type": "Hero",
+      "props": {
+        "title": "Find Your Next Leaders",
+        "subtitle": "Leadership Hiring",
+        "description": "Targeted recruitment for directors, VPs and high-potential talent.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Get Started with Leadership Hiring",
+        "description": "Partner with us to build a strong leadership pipeline.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Request Consultation",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/our-approach.json
+++ b/apps/website/src/content/pages/our-approach.json
@@ -1,0 +1,43 @@
+{
+  "slug": "our-approach",
+  "title": "Our Approach",
+  "status": "published",
+  "seo": {
+    "title": "Our Approach - Networkk",
+    "description": "Discover our proven methodology for connecting leaders with opportunities.",
+    "canonical": "https://networkk.com/our-approach/",
+    "noindex": false,
+    "keywords": ["recruitment process", "executive search methodology"]
+  },
+  "blocks": [
+    {
+      "id": "hero-our-approach",
+      "type": "Hero",
+      "props": {
+        "title": "Our Proven Methodology",
+        "subtitle": "Our Approach",
+        "description": "Transparent processes built on research, evaluation and partnership.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Experience the Networkk Difference",
+        "description": "Partner with us for a collaborative hiring journey.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Get in Touch",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/partner-with-us.json
+++ b/apps/website/src/content/pages/partner-with-us.json
@@ -1,0 +1,43 @@
+{
+  "slug": "partner-with-us",
+  "title": "Partner With Us",
+  "status": "published",
+  "seo": {
+    "title": "Partner With Networkk",
+    "description": "Explore partnership models and the benefits of collaborating with Networkk.",
+    "canonical": "https://networkk.com/partner-with-us/",
+    "noindex": false,
+    "keywords": ["partnership", "engagement models", "talent partner"]
+  },
+  "blocks": [
+    {
+      "id": "hero-partner-with-us",
+      "type": "Hero",
+      "props": {
+        "title": "Collaborate with Networkk",
+        "subtitle": "Partner With Us",
+        "description": "Flexible engagement models designed for shared success.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Become a Networkk Partner",
+        "description": "Let's discuss the right partnership model for your organization.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Contact Us",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/services.json
+++ b/apps/website/src/content/pages/services.json
@@ -40,28 +40,28 @@
             "title": "Executive Search",
             "description": "Identifying and securing C-suite and senior leadership talent who align with your vision and drive transformational growth.",
             "icon": "🎯",
-            "href": "/services/executive-search",
+            "href": "/executive-search",
             "image": "https://images.pexels.com/photos/3184394/pexels-photo-3184394.jpeg?auto=compress&cs=tinysrgb&w=600&h=400&fit=crop"
           },
           {
             "title": "Leadership Hiring",
             "description": "Strategic recruitment for directors, VPs, and emerging leaders who will shape your organization's future and cultural evolution.",
             "icon": "👥",
-            "href": "/services/leadership-hiring",
+            "href": "/leadership-hiring",
             "image": "https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=600&h=400&fit=crop"
           },
           {
             "title": "Talent Advisory",
             "description": "Strategic guidance on leadership development, succession planning, and organizational design for sustainable competitive advantage.",
             "icon": "💡",
-            "href": "/services/talent-advisory",
+            "href": "/talent-advisory",
             "image": "https://images.pexels.com/photos/3184419/pexels-photo-3184419.jpeg?auto=compress&cs=tinysrgb&w=600&h=400&fit=crop"
           },
           {
             "title": "D&I Consulting",
             "description": "Build diverse, inclusive leadership teams that reflect your values, drive innovation, and create lasting organizational change.",
             "icon": "🌟",
-            "href": "/services/diversity-inclusion",
+            "href": "/diversity-inclusion",
             "image": "https://images.pexels.com/photos/3184357/pexels-photo-3184357.jpeg?auto=compress&cs=tinysrgb&w=600&h=400&fit=crop"
           }
         ]

--- a/apps/website/src/content/pages/talent-advisory.json
+++ b/apps/website/src/content/pages/talent-advisory.json
@@ -1,0 +1,43 @@
+{
+  "slug": "talent-advisory",
+  "title": "Talent Advisory Solutions",
+  "status": "published",
+  "seo": {
+    "title": "Talent Advisory Solutions - Networkk",
+    "description": "Strengthen your talent strategy with tailored advisory services.",
+    "canonical": "https://networkk.com/talent-advisory/",
+    "noindex": false,
+    "keywords": ["talent advisory", "succession planning", "organizational design"]
+  },
+  "blocks": [
+    {
+      "id": "hero-talent-advisory",
+      "type": "Hero",
+      "props": {
+        "title": "Strengthen Your Talent Strategy",
+        "subtitle": "Talent Advisory Solutions",
+        "description": "Advisory services that align leadership capabilities with business goals.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Request an Advisory Session",
+        "description": "Discover how our experts can optimize your talent strategy.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Request Session",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/why-choose-us.json
+++ b/apps/website/src/content/pages/why-choose-us.json
@@ -1,0 +1,43 @@
+{
+  "slug": "why-choose-us",
+  "title": "Why Choose Us",
+  "status": "published",
+  "seo": {
+    "title": "Why Choose Networkk",
+    "description": "Learn what sets Networkk apart in executive search and leadership hiring.",
+    "canonical": "https://networkk.com/why-choose-us/",
+    "noindex": false,
+    "keywords": ["why choose us", "networkk difference", "recruitment metrics"]
+  },
+  "blocks": [
+    {
+      "id": "hero-why-choose-us",
+      "type": "Hero",
+      "props": {
+        "title": "Why Leading Brands Choose Networkk",
+        "subtitle": "Why Choose Us",
+        "description": "Performance metrics and client satisfaction that speak for themselves.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Let's Work Together",
+        "description": "Discover how we can help you secure top leadership talent.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Contact Us",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+

--- a/apps/website/src/content/pages/workforce-planning.json
+++ b/apps/website/src/content/pages/workforce-planning.json
@@ -1,0 +1,43 @@
+{
+  "slug": "workforce-planning",
+  "title": "Workforce Planning & Market Mapping",
+  "status": "published",
+  "seo": {
+    "title": "Workforce Planning & Market Mapping - Networkk",
+    "description": "Plan future talent needs with strategic workforce insights and market intelligence.",
+    "canonical": "https://networkk.com/workforce-planning/",
+    "noindex": false,
+    "keywords": ["workforce planning", "market mapping", "talent forecasting"]
+  },
+  "blocks": [
+    {
+      "id": "hero-workforce-planning",
+      "type": "Hero",
+      "props": {
+        "title": "Plan Your Future Talent Needs",
+        "subtitle": "Workforce Planning & Market Mapping",
+        "description": "Data-driven insights to forecast talent demand and understand market dynamics.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    },
+    {
+      "id": "final-cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Request Workforce Insights",
+        "description": "Speak with our consultants about strategic workforce planning.",
+        "backgroundType": "gradient",
+        "primaryCta": {
+          "label": "Request Insights",
+          "href": "/contact"
+        }
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}
+


### PR DESCRIPTION
## Summary
- add content pages for services and resources such as executive search, leadership hiring, talent advisory and more
- update home and services links to point to new pages

## Testing
- `npm run lint --prefix apps/website` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check --prefix apps/website`


------
https://chatgpt.com/codex/tasks/task_e_68a21d2aec208331b5cd340a8725cd5c