### PR TITLE
feat: scaffold CMS app with Next.js and Prisma schema

### DIFF
--- a/apps/cms/.eslintrc.cjs
+++ b/apps/cms/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['next/core-web-vitals'],
+};

--- a/apps/cms/app/layout.tsx
+++ b/apps/cms/app/layout.tsx
@@ -1,0 +1,15 @@
+export const metadata = {
+  title: 'Networkk CMS',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/cms/app/page.tsx
+++ b/apps/cms/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <main>
+      <h1>CMS Home</h1>
+      <p>Welcome to the Networkk CMS.</p>
+    </main>
+  );
+}

--- a/apps/cms/next-env.d.ts
+++ b/apps/cms/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "cms",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "type-check": "tsc --noEmit",
+    "clean": "rm -rf .next"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.17",
+    "@types/react": "^18.2.55",
+    "typescript": "^5.3.3",
+    "prisma": "^5.14.0",
+    "@prisma/client": "^5.14.0"
+  }
+}

--- a/apps/cms/prisma/schema.prisma
+++ b/apps/cms/prisma/schema.prisma
@@ -1,0 +1,64 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum Role {
+  ADMIN
+  EDITOR
+  AUTHOR
+  VIEWER
+}
+
+enum Status {
+  DRAFT
+  REVIEW
+  PUBLISHED
+  ARCHIVED
+}
+
+model User {
+  id           Int      @id @default(autoincrement())
+  email        String   @unique
+  name         String?
+  passwordHash String
+  role         Role     @default(EDITOR)
+  createdAt    DateTime @default(now())
+}
+
+model Page {
+  id          Int       @id @default(autoincrement())
+  slug        String    @unique
+  title       String
+  status      Status    @default(DRAFT)
+  seo         Json
+  blocks      Json
+  updatedById Int?
+  publishedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+}
+
+model Asset {
+  id        Int      @id @default(autoincrement())
+  filename  String
+  url       String
+  width     Int?
+  height    Int?
+  alt       String?
+  meta      Json
+  createdAt DateTime @default(now())
+}
+
+model Revision {
+  id         Int      @id @default(autoincrement())
+  entityType String
+  entityId   Int
+  snapshot   Json
+  editorId   Int?
+  createdAt  DateTime @default(now())
+}

--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "moduleResolution": "bundler"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold `apps/cms` Next.js app with initial layout and home page
- add Prisma schema for core CMS models (User, Page, Asset, Revision)
- basic config files for TypeScript and ESLint

## Testing
- `npm install` *(fails: 403 Forbidden for @prisma/client)*
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: next not found / no ESLint config)*
- `npm run type-check` *(fails: Astro build canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68a221265afc8331a10ade9962c137e8