### PR TITLE
feat(cms): add basic auth scaffold

### DIFF
--- a/apps/cms/next-env.d.ts
+++ b/apps/cms/next-env.d.ts
@@ -1,4 +1,6 @@
+/// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/cms/next.config.mjs
+++ b/apps/cms/next.config.mjs
@@ -1,5 +1,3 @@
-import { NextConfig } from 'next';
-
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
@@ -7,4 +5,4 @@ const nextConfig = {
   }
 };
 
-export default nextConfig satisfies NextConfig;
+export default nextConfig;

--- a/apps/cms/pages/_app.tsx
+++ b/apps/cms/pages/_app.tsx
@@ -1,5 +1,10 @@
 import type { AppProps } from 'next/app';
+import { SessionProvider } from 'next-auth/react';
 
-export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
+  return (
+    <SessionProvider session={session}>
+      <Component {...pageProps} />
+    </SessionProvider>
+  );
 }

--- a/apps/cms/pages/api/auth/[...nextauth].ts
+++ b/apps/cms/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,29 @@
+import NextAuth from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import prisma from '@/lib/prisma';
+
+export const authOptions = {
+  session: { strategy: 'jwt' as const },
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'text' },
+        password: { label: 'Password', type: 'password' }
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) return null;
+        const user = await prisma.user.findUnique({ where: { email: credentials.email } });
+        if (!user) return null;
+        // For now we compare plain text. In production, hash and verify passwords securely.
+        if (user.passwordHash !== credentials.password) return null;
+        return { id: String(user.id), email: user.email, name: user.name, role: user.role } as any;
+      }
+    })
+  ],
+  pages: {
+    signIn: '/login'
+  }
+};
+
+export default NextAuth(authOptions);

--- a/apps/cms/pages/index.tsx
+++ b/apps/cms/pages/index.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useState } from 'react';
+import type { GetServerSideProps } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './api/auth/[...nextauth]';
 
 type Page = { id: number; title: string };
 
@@ -20,3 +23,11 @@ export default function Home() {
     </main>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getServerSession(context.req, context.res, authOptions);
+  if (!session) {
+    return { redirect: { destination: '/login', permanent: false } };
+  }
+  return { props: {} };
+};

--- a/apps/cms/pages/login.tsx
+++ b/apps/cms/pages/login.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/router';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await signIn('credentials', {
+      email,
+      password,
+      redirect: false
+    });
+    if (!res?.error) {
+      router.push('/');
+    } else {
+      alert('Invalid credentials');
+    }
+  }
+
+  return (
+    <main style={{ padding: 16 }}>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>Email</label>
+          <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+        </div>
+        <div>
+          <label>Password</label>
+          <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+        <button type="submit">Sign In</button>
+      </form>
+    </main>
+  );
+}

--- a/apps/cms/tsconfig.json
+++ b/apps/cms/tsconfig.json
@@ -2,16 +2,37 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "moduleResolution": "bundler"
-  },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add credential-based NextAuth configuration for CMS
- add login page and session provider
- require authentication for CMS dashboard
- clean up Next.js and TypeScript configs

## Testing
- `npm run lint --workspace=cms` *(fails: ESLint must be installed)*
- `npm run type-check --workspace=cms`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22eaae5448331a587a3eb4cb3aa41