### PR TITLE
fix prisma generation and hoist workspace deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+workspaces=true
+install-strategy=hoisted

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "npm run prisma:generate",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/apps/cms/prisma/schema.prisma
+++ b/apps/cms/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
## Summary
- add predev step to generate Prisma client
- hoist workspace dependencies via .npmrc
- switch Prisma schema to PostgreSQL provider

## Testing
- `npm run dev --workspace=cms`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2354a9f08833184a3a16498b38a2b