### PR TITLE
fix: mark cms pages as client

### DIFF
--- a/apps/cms/pages/_app.tsx
+++ b/apps/cms/pages/_app.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { AppProps } from 'next/app';
 import { SessionProvider } from 'next-auth/react';
 

--- a/apps/cms/pages/index.tsx
+++ b/apps/cms/pages/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import type { GetServerSideProps } from 'next';
 import { getServerSession } from 'next-auth/next';

--- a/apps/cms/pages/login.tsx
+++ b/apps/cms/pages/login.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/router';


### PR DESCRIPTION
## Summary
- mark CMS login, index and app pages as client components

## Testing
- `npm test --workspaces --if-present`
- `npm run lint` *(fails: ESLint must be installed)*
- `cd apps/cms && npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a2381288288331a91798fc85c58b14