### PR TITLE
feat: add page editor and preview safeguards

### DIFF
--- a/apps/cms/components/LinkAssistant.tsx
+++ b/apps/cms/components/LinkAssistant.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  content: string;
+}
+
+const LINKS = [
+  { keyword: 'Services', href: '/services' },
+  { keyword: 'Insights', href: '/insights' },
+  { keyword: 'Case Studies', href: '/case-studies' }
+];
+
+export default function LinkAssistant({ content }: Props) {
+  const suggestions = LINKS.filter((l) => !content.includes(l.keyword));
+  if (suggestions.length === 0) return null;
+  return (
+    <div className="rounded border p-4">
+      <h2 className="mb-2 font-semibold">Link Assistant</h2>
+      <ul className="list-disc pl-5 text-sm">
+        {suggestions.map((s) => (
+          <li key={s.href}>
+            Consider linking to <a href={s.href}>{s.keyword}</a>.
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/cms/components/SeoPanel.tsx
+++ b/apps/cms/components/SeoPanel.tsx
@@ -1,0 +1,49 @@
+import { ChangeEvent } from 'react';
+
+interface SeoValues {
+  title: string;
+  description: string;
+}
+
+interface Props {
+  value: SeoValues;
+  onChange: (value: SeoValues) => void;
+}
+
+function pixelWidth(str: string) {
+  return Math.round(str.length * 7); // rough estimate
+}
+
+export default function SeoPanel({ value, onChange }: Props) {
+  const handleTitle = (e: ChangeEvent<HTMLInputElement>) =>
+    onChange({ ...value, title: e.target.value });
+  const handleDescription = (e: ChangeEvent<HTMLTextAreaElement>) =>
+    onChange({ ...value, description: e.target.value });
+  return (
+    <div className="space-y-2 rounded border p-4">
+      <h2 className="font-semibold">SEO</h2>
+      <div>
+        <label className="block text-sm font-medium">Title</label>
+        <input
+          className="w-full rounded border px-2 py-1"
+          value={value.title}
+          onChange={handleTitle}
+        />
+        <p className="text-xs text-gray-500">
+          {value.title.length} characters (~{pixelWidth(value.title)}px)
+        </p>
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Description</label>
+        <textarea
+          className="w-full rounded border px-2 py-1"
+          value={value.description}
+          onChange={handleDescription}
+        />
+        <p className="text-xs text-gray-500">
+          {value.description.length} characters (~{pixelWidth(value.description)}px)
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/cms/pages/api/preview/page.ts
+++ b/apps/cms/pages/api/preview/page.ts
@@ -8,6 +8,8 @@ const querySchema = z.object({
 });
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('X-Robots-Tag', 'noindex');
+  res.setHeader('Cache-Control', 'no-store');
   const { slug } = querySchema.parse(req.query);
   const page = await prisma.page.findUnique({ where: { slug } });
   if (!page) {

--- a/apps/cms/pages/api/preview/stream.ts
+++ b/apps/cms/pages/api/preview/stream.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
 import { subscribe, unsubscribe } from '@/lib/preview';
 
 export const config = {
@@ -7,12 +8,15 @@ export const config = {
   }
 };
 
+const querySchema = z.object({ slug: z.string().default('/') });
+
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const slug = (req.query.slug as string) ?? '/';
+  const { slug } = querySchema.parse(req.query);
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
-    Connection: 'keep-alive'
+    'Cache-Control': 'no-store',
+    Connection: 'keep-alive',
+    'X-Robots-Tag': 'noindex'
   });
   res.write('\n');
   subscribe(slug, res);

--- a/apps/cms/pages/pages/[id].tsx
+++ b/apps/cms/pages/pages/[id].tsx
@@ -1,0 +1,107 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import Layout from '../../components/Layout';
+import SeoPanel from '../../components/SeoPanel';
+import LinkAssistant from '../../components/LinkAssistant';
+import type { GetServerSideProps } from 'next';
+import { requireAuth } from '../../lib/auth';
+
+interface PageData {
+  title: string;
+  content: string;
+  seo: { title: string; description: string };
+}
+
+export default function PageEditor() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<PageData>({
+    title: '',
+    content: '',
+    seo: { title: '', description: '' }
+  });
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/pages/${id}`)
+      .then((res) => res.json())
+      .then((json) => {
+        setData({
+          title: json.title ?? '',
+          content: json.blocks ? JSON.stringify(json.blocks, null, 2) : '',
+          seo: {
+            title: json.seo?.title ?? '',
+            description: json.seo?.description ?? ''
+          }
+        });
+        setLoading(false);
+      });
+  }, [id]);
+
+  const save = async () => {
+    await fetch(`/api/pages/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: data.title,
+        seo: data.seo,
+        blocks: data.content
+      })
+    });
+    alert('Saved');
+  };
+
+  if (loading) {
+    return (
+      <Layout>
+        <p>Loading…</p>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <h1 className="mb-4 text-2xl font-bold">Edit Page</h1>
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium">Title</label>
+          <input
+            className="w-full rounded border px-2 py-1"
+            value={data.title}
+            onChange={(e) => setData({ ...data, title: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Content</label>
+          <textarea
+            className="w-full rounded border px-2 py-1 min-h-[200px]"
+            value={data.content}
+            onChange={(e) => setData({ ...data, content: e.target.value })}
+          />
+        </div>
+        <SeoPanel
+          value={data.seo}
+          onChange={(seo) => setData({ ...data, seo })}
+        />
+        <LinkAssistant content={data.content} />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={save}
+            className="rounded bg-blue-600 px-3 py-1 text-white"
+          >
+            Save
+          </button>
+          <Link href="/builder" className="rounded bg-gray-200 px-3 py-1">
+            Open in Builder
+          </Link>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = (ctx) =>
+  requireAuth(ctx, async () => ({ props: {} }));

--- a/apps/cms/pages/pages/index.tsx
+++ b/apps/cms/pages/pages/index.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import type { GetServerSideProps } from 'next';
-import Layout from '../components/Layout';
-import DataState from '../components/DataState';
-import { requireAuth } from '../lib/auth';
+import Link from 'next/link';
+import Layout from '../../components/Layout';
+import DataState from '../../components/DataState';
+import { requireAuth } from '../../lib/auth';
 
 interface Item { id: number; title: string }
 
@@ -24,7 +25,14 @@ export default function Pages() {
       <DataState loading={loading} items={items} error={null}>
         <ul>
           {items.map((p) => (
-            <li key={p.id}>{p.title}</li>
+            <li key={p.id} className="flex gap-2">
+              <Link href={`/pages/${p.id}`} className="text-blue-600 hover:underline">
+                {p.title}
+              </Link>
+              <Link href="/builder" className="text-sm text-gray-600 hover:underline">
+                Open in Builder
+              </Link>
+            </li>
           ))}
         </ul>
       </DataState>


### PR DESCRIPTION
## Summary
- add textual page editor with SEO panel and link assistant
- expose "Open in Builder" link and link suggestions for pages
- harden preview APIs with typed slug and noindex/no-store headers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint not installed)*
- `npm run type-check` *(fails: tsc --noEmit)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e5452e8883318262f8e20f5d1eec