### PR TITLE
feat(cms): add media metadata and publishing pipeline

### DIFF
--- a/apps/cms/components/builder/VisualBuilder.tsx
+++ b/apps/cms/components/builder/VisualBuilder.tsx
@@ -254,6 +254,51 @@ export default function VisualBuilder() {
     }
   };
 
+  const exportJSON = () => {
+    const json = JSON.stringify(blocks, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'content.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const blocksToMDX = (items: BlockInstance[]) =>
+    items
+      .map((b) => {
+        switch (b.type) {
+          case 'image':
+            return `![${b.data.alt}](${b.data.url})`;
+          case 'text':
+            return b.data.asList
+              ? b.data.text
+                  .split('\n')
+                  .map((t: string) => `- ${t}`)
+                  .join('\n')
+              : b.data.text;
+          case 'cta':
+            return `[${b.data.text}](${b.data.url})`;
+          case 'hero':
+            return `## ${b.data.heading}\n${b.data.content ?? ''}`;
+          default:
+            return '';
+        }
+      })
+      .join('\n\n');
+
+  const exportMDX = () => {
+    const mdx = blocksToMDX(blocks);
+    const blob = new Blob([mdx], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'content.mdx';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   const validateSEO = (items: BlockInstance[]) => {
     const errors: string[] = [];
     items.forEach((b, idx) => {
@@ -297,6 +342,20 @@ export default function VisualBuilder() {
             className="mt-2 w-full rounded bg-gray-200 px-2 py-1"
           >
             Load Snippet
+          </button>
+          <button
+            type="button"
+            onClick={exportJSON}
+            className="mt-2 w-full rounded bg-gray-200 px-2 py-1"
+          >
+            Export JSON
+          </button>
+          <button
+            type="button"
+            onClick={exportMDX}
+            className="mt-2 w-full rounded bg-gray-200 px-2 py-1"
+          >
+            Export MDX
           </button>
         </aside>
         <div className="flex-1" aria-label="Canvas" ref={setCanvasRef}>

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "predev": "npm run prisma:generate",
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && node scripts/seo-lint.mjs",
     "start": "next start",
     "lint": "next lint",
     "prisma": "prisma",

--- a/apps/cms/pages/media.tsx
+++ b/apps/cms/pages/media.tsx
@@ -8,6 +8,11 @@ interface MediaItem {
   id: number;
   title: string;
   url: string;
+  alt: string;
+  caption?: string;
+  credit?: string;
+  license?: string;
+  focal: { x: number; y: number };
 }
 
 export default function Media() {
@@ -24,7 +29,18 @@ export default function Media() {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      setItems([{ id: 1, title: 'logo.png', url: '/logo.png' }]);
+      setItems([
+        {
+          id: 1,
+          title: 'logo.png',
+          url: '/logo.png',
+          alt: 'Networkk logo',
+          caption: '',
+          credit: '',
+          license: '',
+          focal: { x: 50, y: 50 }
+        }
+      ]);
       setLoading(false);
     }, 600);
     return () => clearTimeout(timer);
@@ -72,7 +88,16 @@ export default function Media() {
     await Promise.all([convert(file, 'image/webp'), convert(file, 'image/avif')]);
     setItems((prev) => [
       ...prev,
-      { id: prev.length + 1, title: filename || file.name, url: URL.createObjectURL(file) }
+      {
+        id: prev.length + 1,
+        title: filename || file.name,
+        url: URL.createObjectURL(file),
+        alt,
+        caption,
+        credit,
+        license,
+        focal
+      }
     ]);
     setTitle('');
     setFilename('');
@@ -160,7 +185,10 @@ export default function Media() {
       <DataState loading={loading} items={items} error={null}>
         <ul>
           {items.map((p) => (
-            <li key={p.id}>{p.title}</li>
+            <li key={p.id}>
+              {p.title}
+              <span className="ml-2 text-sm text-gray-600">{p.alt}</span>
+            </li>
           ))}
         </ul>
       </DataState>

--- a/apps/cms/scripts/seo-lint.mjs
+++ b/apps/cms/scripts/seo-lint.mjs
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const pagesDir = path.resolve(__dirname, '../../website/src/content/pages');
+const files = fs.readdirSync(pagesDir).filter((f) => f.endsWith('.json'));
+const errors = [];
+
+for (const file of files) {
+  const data = JSON.parse(fs.readFileSync(path.join(pagesDir, file), 'utf8'));
+  const { seo = {}, blocks = [] } = data;
+
+  if (!seo.title) {
+    errors.push(`${file}: missing seo.title`);
+  }
+  if (!seo.description) {
+    errors.push(`${file}: missing seo.description`);
+  }
+
+  blocks.forEach((block, idx) => {
+    if (block.type === 'Hero' && block.props?.media && !block.props.media.alt) {
+      errors.push(`${file}: Hero block #${idx + 1} missing alt text`);
+    }
+  });
+}
+
+if (errors.length) {
+  console.error('SEO issues found:');
+  for (const err of errors) {
+    console.error(' -', err);
+  }
+  process.exit(1);
+} else {
+  console.log('SEO linter: no critical issues found.');
+}

--- a/apps/cms/vercel.json
+++ b/apps/cms/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## Summary
- extend media library with alt, caption, credit, license and focal point data
- add JSON/MDX export utilities to visual builder
- run SEO linter after builds via dedicated script and Vercel config

## Testing
- `pnpm lint --workspace=cms` (fails: ESLint must be installed)
- `pnpm type-check --workspace=cms` (fails: missing @types/react-grid-layout)
- `pnpm build --workspace=cms` (fails: ESLint must be installed)
- `node apps/cms/scripts/seo-lint.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68a2f6a3c4b483319b35bd340f2614df