### PR TITLE
feat: enhance seo validation

### DIFF
--- a/apps/cms/components/SeoPanel.tsx
+++ b/apps/cms/components/SeoPanel.tsx
@@ -3,6 +3,7 @@ import { ChangeEvent } from 'react';
 interface SeoValues {
   title: string;
   description: string;
+  canonical: string;
 }
 
 interface Props {
@@ -19,6 +20,8 @@ export default function SeoPanel({ value, onChange }: Props) {
     onChange({ ...value, title: e.target.value });
   const handleDescription = (e: ChangeEvent<HTMLTextAreaElement>) =>
     onChange({ ...value, description: e.target.value });
+  const handleCanonical = (e: ChangeEvent<HTMLInputElement>) =>
+    onChange({ ...value, canonical: e.target.value });
   return (
     <div className="space-y-2 rounded border p-4">
       <h2 className="font-semibold">SEO</h2>
@@ -43,6 +46,14 @@ export default function SeoPanel({ value, onChange }: Props) {
         <p className="text-xs text-gray-500">
           {value.description.length} characters (~{pixelWidth(value.description)}px)
         </p>
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Canonical URL</label>
+        <input
+          className="w-full rounded border px-2 py-1"
+          value={value.canonical}
+          onChange={handleCanonical}
+        />
       </div>
     </div>
   );

--- a/apps/cms/pages/pages/[id].tsx
+++ b/apps/cms/pages/pages/[id].tsx
@@ -10,7 +10,7 @@ import { requireAuth } from '../../lib/auth';
 interface PageData {
   title: string;
   content: string;
-  seo: { title: string; description: string };
+  seo: { title: string; description: string; canonical: string };
 }
 
 export default function PageEditor() {
@@ -20,7 +20,7 @@ export default function PageEditor() {
   const [data, setData] = useState<PageData>({
     title: '',
     content: '',
-    seo: { title: '', description: '' }
+    seo: { title: '', description: '', canonical: '' }
   });
 
   useEffect(() => {
@@ -33,7 +33,8 @@ export default function PageEditor() {
           content: json.blocks ? JSON.stringify(json.blocks, null, 2) : '',
           seo: {
             title: json.seo?.title ?? '',
-            description: json.seo?.description ?? ''
+            description: json.seo?.description ?? '',
+            canonical: json.seo?.canonical ?? ''
           }
         });
         setLoading(false);

--- a/apps/cms/scripts/seo-lint.mjs
+++ b/apps/cms/scripts/seo-lint.mjs
@@ -5,6 +5,8 @@ const __dirname = path.dirname(new URL(import.meta.url).pathname);
 const pagesDir = path.resolve(__dirname, '../../website/src/content/pages');
 const files = fs.readdirSync(pagesDir).filter((f) => f.endsWith('.json'));
 const errors = [];
+const titles = new Map();
+const globalH1s = new Map();
 
 for (const file of files) {
   const data = JSON.parse(fs.readFileSync(path.join(pagesDir, file), 'utf8'));
@@ -12,16 +14,62 @@ for (const file of files) {
 
   if (!seo.title) {
     errors.push(`${file}: missing seo.title`);
-  }
-  if (!seo.description) {
-    errors.push(`${file}: missing seo.description`);
+  } else {
+    if (seo.title.length > 60) {
+      errors.push(`${file}: seo.title longer than 60 characters`);
+    }
+    if (titles.has(seo.title)) {
+      errors.push(`${file}: duplicate seo.title also in ${titles.get(seo.title)}`);
+    } else {
+      titles.set(seo.title, file);
+    }
   }
 
+  if (!seo.description) {
+    errors.push(`${file}: missing seo.description`);
+  } else {
+    const len = seo.description.length;
+    if (len < 120 || len > 160) {
+      errors.push(`${file}: seo.description length ${len} outside 120-160 characters`);
+    }
+  }
+
+  if (!seo.canonical) {
+    errors.push(`${file}: missing seo.canonical`);
+  }
+
+  if (seo.jsonldRequired && !seo.jsonld) {
+    errors.push(`${file}: missing required JSON-LD`);
+  }
+
+  const pageH1s = [];
+
   blocks.forEach((block, idx) => {
-    if (block.type === 'Hero' && block.props?.media && !block.props.media.alt) {
-      errors.push(`${file}: Hero block #${idx + 1} missing alt text`);
+    const props = block.props || {};
+    if (props.media && !props.media.alt) {
+      errors.push(`${file}: ${block.type} block #${idx + 1} missing alt text`);
+    }
+    if (block.type === 'Hero' && props.title) {
+      pageH1s.push(props.title);
+      if (globalH1s.has(props.title)) {
+        errors.push(`${file}: duplicate H1 "${props.title}" also in ${globalH1s.get(props.title)}`);
+      } else {
+        globalH1s.set(props.title, file);
+      }
+    }
+    if (block.type === 'Heading' && props.level === 1 && props.text) {
+      pageH1s.push(props.text);
+      if (globalH1s.has(props.text)) {
+        errors.push(`${file}: duplicate H1 "${props.text}" also in ${globalH1s.get(props.text)}`);
+      } else {
+        globalH1s.set(props.text, file);
+      }
     }
   });
+
+  if (pageH1s.length > 1) {
+    errors.push(`${file}: multiple H1s`);
+  }
 }
 
 if (errors.length) {


### PR DESCRIPTION
## Summary
- add canonical url field in SEO panel and page editor
- extend SEO linter for canonical, title/description limits, duplicate title/H1, JSON-LD checks

## Testing
- `npm --prefix apps/cms run lint` *(fails: ESLint must be installed)*
- `npm --prefix apps/cms run build` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3049518ec8331ba17561b1fff03f7