### PR TITLE
feat(cms): add notification system

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -13,6 +13,7 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",
     "type-check": "tsc --noEmit",
+    "digest": "node scripts/daily-digest.mjs",
     "clean": "rmdir /s /q .next 2>nul || echo .next directory cleaned"
   },
   "dependencies": {

--- a/apps/cms/pages/api/notifications/index.ts
+++ b/apps/cms/pages/api/notifications/index.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '@/lib/prisma';
+import { z } from 'zod';
+import { NotificationEvent, NotificationChannel } from '@prisma/client';
+
+const querySchema = z.object({
+  userId: z.coerce.number().optional(),
+  limit: z.coerce.number().min(1).max(100).optional(),
+  offset: z.coerce.number().min(0).optional()
+});
+
+const createSchema = z.object({
+  userId: z.number().optional(),
+  templateId: z.number(),
+  data: z.any().default({})
+});
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const { userId, limit, offset } = querySchema.parse(req.query);
+    const where: any = {};
+    if (userId) where.userId = userId;
+    const items = await prisma.notification.findMany({ where, skip: offset, take: limit });
+    const total = await prisma.notification.count({ where });
+    res.json({ items, total });
+  } else if (req.method === 'POST') {
+    const { userId, templateId, data } = createSchema.parse(req.body);
+    const template = await prisma.notificationTemplate.findUnique({ where: { id: templateId } });
+    if (!template) {
+      res.status(400).json({ error: 'Invalid template' });
+      return;
+    }
+    const notification = await prisma.notification.create({
+      data: {
+        userId,
+        templateId,
+        event: template.event,
+        channel: template.channel,
+        data
+      }
+    });
+    await prisma.notificationAudit.create({
+      data: {
+        notificationId: notification.id,
+        event: template.event,
+        message: 'created'
+      }
+    });
+    res.status(201).json({ id: notification.id });
+  } else {
+    res.setHeader('Allow', 'GET,POST');
+    res.status(405).end();
+  }
+}

--- a/apps/cms/pages/api/notifications/preferences.ts
+++ b/apps/cms/pages/api/notifications/preferences.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '@/lib/prisma';
+import { z } from 'zod';
+import { NotificationEvent, NotificationChannel } from '@prisma/client';
+
+const querySchema = z.object({
+  userId: z.coerce.number()
+});
+
+const updateSchema = z.object({
+  userId: z.number(),
+  event: z.nativeEnum(NotificationEvent),
+  channel: z.nativeEnum(NotificationChannel),
+  enabled: z.boolean().default(true)
+});
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const { userId } = querySchema.parse(req.query);
+    const items = await prisma.notificationPreference.findMany({ where: { userId } });
+    res.json({ items });
+  } else if (req.method === 'POST') {
+    const data = updateSchema.parse(req.body);
+    await prisma.notificationPreference.upsert({
+      where: {
+        userId_event_channel: {
+          userId: data.userId,
+          event: data.event,
+          channel: data.channel
+        }
+      },
+      update: { enabled: data.enabled },
+      create: data
+    });
+    res.status(204).end();
+  } else {
+    res.setHeader('Allow', 'GET,POST');
+    res.status(405).end();
+  }
+}

--- a/apps/cms/pages/api/notifications/templates.ts
+++ b/apps/cms/pages/api/notifications/templates.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '@/lib/prisma';
+import { z } from 'zod';
+import { NotificationEvent, NotificationChannel } from '@prisma/client';
+
+const querySchema = z.object({
+  event: z.nativeEnum(NotificationEvent).optional(),
+  channel: z.nativeEnum(NotificationChannel).optional()
+});
+
+const createSchema = z.object({
+  event: z.nativeEnum(NotificationEvent),
+  channel: z.nativeEnum(NotificationChannel),
+  subject: z.string().optional(),
+  body: z.string().min(1)
+});
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const { event, channel } = querySchema.parse(req.query);
+    const where: any = {};
+    if (event) where.event = event;
+    if (channel) where.channel = channel;
+    const items = await prisma.notificationTemplate.findMany({ where });
+    res.json({ items });
+  } else if (req.method === 'POST') {
+    const data = createSchema.parse(req.body);
+    const template = await prisma.notificationTemplate.create({ data });
+    res.status(201).json({ id: template.id });
+  } else {
+    res.setHeader('Allow', 'GET,POST');
+    res.status(405).end();
+  }
+}

--- a/apps/cms/prisma/schema.prisma
+++ b/apps/cms/prisma/schema.prisma
@@ -21,6 +21,21 @@ enum Status {
   ARCHIVED
 }
 
+enum NotificationChannel {
+  EMAIL
+  SMS
+  WEBHOOK
+  IN_APP
+}
+
+enum NotificationEvent {
+  PUBLISH_SUCCESS
+  PUBLISH_FAILURE
+  DUPLICATE_TITLE
+  BROKEN_LINK_REPORT
+  DAILY_DIGEST
+}
+
 model User {
   id           Int      @id @default(autoincrement())
   email        String   @unique
@@ -28,6 +43,8 @@ model User {
   passwordHash String
   role         Role     @default(EDITOR)
   createdAt    DateTime @default(now())
+  notifications          Notification[]
+  notificationPreferences NotificationPreference[]
 }
 
 model Page {
@@ -61,4 +78,48 @@ model Revision {
   snapshot   Json
   editorId   Int?
   createdAt  DateTime @default(now())
+}
+
+model NotificationTemplate {
+  id        Int                 @id @default(autoincrement())
+  event     NotificationEvent
+  channel   NotificationChannel
+  subject   String?
+  body      String
+  createdAt DateTime            @default(now())
+  notifications Notification[]
+}
+
+model Notification {
+  id          Int                 @id @default(autoincrement())
+  userId      Int?
+  templateId  Int
+  event       NotificationEvent
+  channel     NotificationChannel
+  data        Json
+  sentAt      DateTime            @default(now())
+  readAt      DateTime?
+  status      String?
+  user        User?               @relation(fields: [userId], references: [id])
+  template    NotificationTemplate @relation(fields: [templateId], references: [id])
+  audits      NotificationAudit[]
+}
+
+model NotificationPreference {
+  id       Int                 @id @default(autoincrement())
+  userId   Int
+  event    NotificationEvent
+  channel  NotificationChannel
+  enabled  Boolean             @default(true)
+  user     User                @relation(fields: [userId], references: [id])
+  @@unique([userId, event, channel])
+}
+
+model NotificationAudit {
+  id             Int          @id @default(autoincrement())
+  notificationId Int?
+  event          NotificationEvent
+  message        String
+  createdAt      DateTime     @default(now())
+  notification   Notification? @relation(fields: [notificationId], references: [id])
 }

--- a/apps/cms/scripts/daily-digest.mjs
+++ b/apps/cms/scripts/daily-digest.mjs
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const pagesDir = path.resolve(__dirname, '../../website/src/content/pages');
+const files = fs.readdirSync(pagesDir).filter((f) => f.endsWith('.json'));
+
+const pagesMissingH2 = [];
+const imagesMissingAlt = [];
+
+for (const file of files) {
+  const data = JSON.parse(fs.readFileSync(path.join(pagesDir, file), 'utf8'));
+  const { blocks = [] } = data;
+  let hasH2 = false;
+  blocks.forEach((block) => {
+    const props = block.props || {};
+    if (block.type === 'Heading' && props.level === 2 && props.text) {
+      hasH2 = true;
+    }
+    if (props.media && !props.media.alt) {
+      imagesMissingAlt.push(`${file}: ${block.type} missing alt text`);
+    }
+  });
+  if (!hasH2) {
+    pagesMissingH2.push(file);
+  }
+}
+
+const summary = {
+  pagesMissingH2,
+  imagesMissingAlt
+};
+
+console.log('Daily SEO digest', JSON.stringify(summary, null, 2));
+
+// Optionally post digest to notification endpoint if env configured
+if (process.env.CMS_URL) {
+  try {
+    fetch(`${process.env.CMS_URL}/api/notifications`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        templateId: 0,
+        data: summary
+      })
+    });
+  } catch {
+    // ignore network errors in digest script
+  }
+}


### PR DESCRIPTION
## Summary
- add Prisma models and enums for notification templates, events, preferences, and audits
- expose notification, template, and preference REST API endpoints
- include daily SEO digest script and npm shortcut

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint --workspace=cms` (fails: ESLint must be installed)
- `npm run type-check --workspace=cms` (fails: could not find types and existing TS errors)
- `npm run digest --workspace=cms`


------
https://chatgpt.com/codex/tasks/task_e_68a3228072b48331a1c048aa781452d3