### PR TITLE
feat: add chat widget and CMS endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ uploads/
 # Generated files
 sitemap*.xml
 robots.txt
+!apps/website/public/robots.txt
+!apps/cms/public/robots.txt

--- a/apps/cms/lib/sessionIndex.ts
+++ b/apps/cms/lib/sessionIndex.ts
@@ -1,0 +1,37 @@
+interface Doc {
+  id: number;
+  text: string;
+  url?: string;
+}
+
+type SessionData = {
+  docs: Doc[];
+  timer: NodeJS.Timeout;
+};
+
+const indexes = new Map<string, SessionData>();
+const TTL = 60 * 60 * 1000; // 1 hour
+
+function createTimer(sessionId: string) {
+  return setTimeout(() => {
+    indexes.delete(sessionId);
+  }, TTL);
+}
+
+export function addDocument(sessionId: string, text: string, url?: string) {
+  const existing = indexes.get(sessionId);
+  if (existing) {
+    clearTimeout(existing.timer);
+    existing.docs.push({ id: existing.docs.length + 1, text, url });
+    existing.timer = createTimer(sessionId);
+  } else {
+    indexes.set(sessionId, {
+      docs: [{ id: 1, text, url }],
+      timer: createTimer(sessionId),
+    });
+  }
+}
+
+export function getDocuments(sessionId: string): Doc[] {
+  return indexes.get(sessionId)?.docs ?? [];
+}

--- a/apps/cms/lib/transcripts.ts
+++ b/apps/cms/lib/transcripts.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+type Message = { role: string; content: string };
+const filePath = path.join(process.cwd(), 'data', 'transcripts.json');
+
+async function readAll() {
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(data) as any[];
+  } catch {
+    return [];
+  }
+}
+
+export async function logTranscript(sessionId: string, messages: Message[]) {
+  const all = await readAll();
+  all.push({ sessionId, messages, timestamp: Date.now() });
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(all, null, 2));
+}
+
+export async function getAnalytics() {
+  const all = await readAll();
+  const totalSessions = all.length;
+  const totalMessages = all.reduce((acc, t) => acc + t.messages.length, 0);
+  return { totalSessions, totalMessages };
+}
+
+export function notifyTeam(sessionId: string) {
+  console.log(`Escalation requested for session ${sessionId}`);
+}

--- a/apps/cms/pages/api/analytics.ts
+++ b/apps/cms/pages/api/analytics.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getAnalytics } from '../../../lib/transcripts';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const analytics = await getAnalytics();
+  res.status(200).json(analytics);
+}

--- a/apps/cms/pages/api/chat.ts
+++ b/apps/cms/pages/api/chat.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDocuments } from '../../../lib/sessionIndex';
+import { logTranscript, notifyTeam } from '../../../lib/transcripts';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+  const { sessionId, message } = req.body || {};
+  if (!sessionId || !message) {
+    return res.status(400).json({ error: 'missing sessionId or message' });
+  }
+  const docs = getDocuments(sessionId);
+  const citation = docs.length ? { label: '[1]', url: docs[0].url || '#' } : null;
+  const answer = docs.length
+    ? `According to your document: ${docs[0].text.slice(0, 100)}...`
+    : 'No documents found for this session.';
+  const response = {
+    message: citation ? `${answer} ${citation.label}` : answer,
+    citations: citation ? [citation] : [],
+  };
+  await logTranscript(sessionId, [
+    { role: 'user', content: message },
+    { role: 'assistant', content: response.message },
+  ]);
+  if (message.toLowerCase().includes('escalate')) {
+    notifyTeam(sessionId);
+  }
+  res.status(200).json(response);
+}

--- a/apps/cms/pages/api/upload.ts
+++ b/apps/cms/pages/api/upload.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { addDocument } from '../../../lib/sessionIndex';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+  const { sessionId, text, url } = req.body || {};
+  if (!sessionId || !text) {
+    return res.status(400).json({ error: 'missing sessionId or text' });
+  }
+  addDocument(sessionId, text, url);
+  res.status(200).json({ ok: true });
+}

--- a/apps/cms/pages/transcripts.tsx
+++ b/apps/cms/pages/transcripts.tsx
@@ -1,0 +1,47 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+type Transcript = {
+  sessionId: string;
+  messages: { role: string; content: string }[];
+  timestamp: number;
+};
+
+interface Props {
+  transcripts: Transcript[];
+}
+
+export default function TranscriptsPage({ transcripts }: Props) {
+  return (
+    <div className="p-4">
+      <Head>
+        <meta name="robots" content="noindex" />
+      </Head>
+      <h1 className="text-2xl mb-4">Transcripts</h1>
+      <ul className="space-y-4">
+        {transcripts.map((t, idx) => (
+          <li key={idx} className="border p-2">
+            <p className="font-bold">Session {t.sessionId}</p>
+            <ul className="ml-4 list-disc">
+              {t.messages.map((m, i) => (
+                <li key={i}>{m.role}: {m.content}</li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async () => {
+  const file = path.join(process.cwd(), 'data', 'transcripts.json');
+  let transcripts: Transcript[] = [];
+  try {
+    const data = await fs.readFile(file, 'utf8');
+    transcripts = JSON.parse(data);
+  } catch {}
+  return { props: { transcripts } };
+};

--- a/apps/cms/public/robots.txt
+++ b/apps/cms/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /api/chat
+Disallow: /api/upload
+Disallow: /transcripts

--- a/apps/website/public/robots.txt
+++ b/apps/website/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /transcripts
+Disallow: /uploads
+Disallow: /api/chat
+Disallow: /chat-preview

--- a/apps/website/src/components/chat/ChatWidget.tsx
+++ b/apps/website/src/components/chat/ChatWidget.tsx
@@ -1,0 +1,93 @@
+import React, { useState, useRef } from 'react';
+
+interface Citation {
+  label: string;
+  url: string;
+}
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+  citations?: Citation[];
+}
+
+export default function ChatWidget() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [consent, setConsent] = useState(false);
+  const sessionId = useRef<string>(crypto.randomUUID());
+
+  const sendMessage = async () => {
+    if (!input) return;
+
+    if (file && consent) {
+      const text = await file.text();
+      await fetch('/api/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: sessionId.current,
+          text,
+          filename: file.name,
+          url: '/',
+        }),
+      });
+    }
+
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: sessionId.current, message: input }),
+    });
+    const data = await res.json();
+    setMessages((prev) => [
+      ...prev,
+      { role: 'user', content: input },
+      { role: 'assistant', content: data.message, citations: data.citations || [] },
+    ]);
+    setInput('');
+    setFile(null);
+  };
+
+  return (
+    <div className="border rounded p-4 max-w-md">
+      <div className="space-y-2 mb-4 max-h-64 overflow-y-auto">
+        {messages.map((m, idx) => (
+          <div key={idx} className={m.role === 'user' ? 'text-right' : ''}>
+            <div className="inline-block bg-gray-100 p-2 rounded">
+              {m.content}{' '}
+              {m.citations?.map((c) => (
+                <a key={c.url} href={c.url} className="text-blue-600 underline ml-1">
+                  {c.label}
+                </a>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="space-y-2">
+        <textarea
+          className="w-full border p-2"
+          rows={3}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <div>
+          <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+          <label className="ml-2">
+            <input type="checkbox" checked={consent} onChange={(e) => setConsent(e.target.checked)} />
+            <span className="ml-1">Allow document indexing this session</span>
+          </label>
+        </div>
+        <button
+          onClick={sendMessage}
+          className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+          disabled={!input}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/pages/chat-preview.astro
+++ b/apps/website/src/pages/chat-preview.astro
@@ -1,0 +1,13 @@
+---
+import ChatWidget from '@/components/chat/ChatWidget';
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Chat Preview</title>
+    <meta name="robots" content="noindex" />
+  </head>
+  <body class="p-4">
+    <ChatWidget client:load />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add frontend chat preview page and widget with document uploads and citation rendering
- implement CMS session index, transcripts logging, and chat/upload/analytics API routes
- disallow chat, upload, and transcript paths via robots.txt

## Testing
- `npm test` *(fails: Missing script "test" in workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_68a3292efa5c83319bbd0464a90a224f