### PR TITLE
style: theme other pages

### DIFF
--- a/apps/website/src/layouts/PageLayout.astro
+++ b/apps/website/src/layouts/PageLayout.astro
@@ -31,6 +31,14 @@ export interface Props {
 
 const { page, showPageTitle = true, theme } = Astro.props;
 
+const themeStyles = {
+  default: { headingBg: 'bg-gray-50', headingText: 'text-gray-900' },
+  gold: { headingBg: 'bg-amber-50', headingText: 'text-amber-900' },
+  emerald: { headingBg: 'bg-emerald-50', headingText: 'text-emerald-900' }
+};
+
+const currentTheme = themeStyles[theme ?? 'default'];
+
 // Generate JSON-LD structured data
 const organizationSchema = JSON.parse(createOrganizationSchema());
 const websiteSchema = JSON.parse(createWebsiteSchema());
@@ -68,9 +76,12 @@ const combinedJsonLd = [
   <JsonLd data={combinedJsonLd} />
   
   {showPageTitle && page.slug !== 'home' && (
-    <section class="section-sm bg-gray-50">
+    <section class={`section-sm ${currentTheme.headingBg}`}>
       <div class="container">
-        <Heading level={1} class="text-center max-w-4xl mx-auto">
+        <Heading
+          level={1}
+          class={`text-center max-w-4xl mx-auto ${currentTheme.headingText}`}
+        >
           {page.title}
         </Heading>
       </div>

--- a/apps/website/src/pages/[slug].astro
+++ b/apps/website/src/pages/[slug].astro
@@ -44,5 +44,5 @@ if (!page) {
 }
 ---
 
-<PageLayout page={page} />
+<PageLayout page={page} theme="emerald" />
 

--- a/apps/website/src/pages/chat-preview.astro
+++ b/apps/website/src/pages/chat-preview.astro
@@ -1,13 +1,17 @@
 ---
+import BaseLayout from '../layouts/BaseLayout.astro';
 import ChatWidget from '@/components/chat/ChatWidget';
 ---
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>Chat Preview</title>
-    <meta name="robots" content="noindex" />
-  </head>
-  <body class="p-4">
+
+<BaseLayout
+  title="Chat Preview"
+  description="Preview of the chat widget"
+  showHeader={false}
+  showFooter={false}
+  footerTheme="gold"
+>
+  <section class="container py-8">
     <ChatWidget client:load />
-  </body>
-</html>
+  </section>
+</BaseLayout>
+


### PR DESCRIPTION
## Summary
- introduce theme-based heading styles in PageLayout
- apply emerald theme to dynamic content pages
- refactor chat preview into BaseLayout with gold theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run type-check` *(fails: Could not find a declaration file for module 'react-grid-layout')*


------
https://chatgpt.com/codex/tasks/task_e_68a3344763908331a4fa477c448783f3