### PR TITLE
feat: expand internal pages and streamline navigation

### DIFF
--- a/apps/website/src/content/pages/careers.json
+++ b/apps/website/src/content/pages/careers.json
@@ -23,6 +23,31 @@
       }
     },
     {
+      "id": "careers-benefits",
+      "type": "TilesGrid",
+      "props": {
+        "heading": "Why Work With Us",
+        "description": "A culture built for growth and flexibility.",
+        "columns": "3",
+        "items": [
+          { "title": "Hybrid Workplace", "description": "Work from anywhere with collaborative hubs.", "icon": "\uD83C\uDF10" },
+          { "title": "Learning Budget", "description": "Annual stipend for courses and conferences.", "icon": "\uD83D\uDCDA" },
+          { "title": "Wellness First", "description": "Comprehensive health plans and recharge days.", "icon": "\uD83D\uDECC" }
+        ]
+      }
+    },
+    {
+      "id": "careers-faq",
+      "type": "FAQ",
+      "props": {
+        "heading": "Hiring FAQs",
+        "items": [
+          { "question": "How do I apply?", "answer": "Send your resume and a brief cover note via our contact form." },
+          { "question": "Do you offer remote roles?", "answer": "Yes, many roles are remote-friendly with flexible schedules." }
+        ]
+      }
+    },
+    {
       "id": "final-cta",
       "type": "CTA",
       "props": {

--- a/apps/website/src/content/pages/case-studies.json
+++ b/apps/website/src/content/pages/case-studies.json
@@ -270,6 +270,23 @@
       }
     },
     {
+      "id": "case-testimonials",
+      "type": "Testimonials",
+      "props": {
+        "heading": "Client Voices",
+        "items": [
+          {
+            "quote": "The leaders we hired through Networkk delivered immediate impact.",
+            "author": { "name": "Lena Matthews", "title": "COO", "company": "RetailCo" }
+          },
+          {
+            "quote": "Their understanding of our culture made the search effortless.",
+            "author": { "name": "Arjun Rao", "title": "Chairman", "company": "TechStart" }
+          }
+        ]
+      }
+    },
+    {
       "id": "case-studies-cta",
       "type": "CTA",
       "props": {

--- a/apps/website/src/content/pages/diversity-inclusion.json
+++ b/apps/website/src/content/pages/diversity-inclusion.json
@@ -23,6 +23,34 @@
       }
     },
     {
+      "id": "pillars-di",
+      "type": "TilesGrid",
+      "props": {
+        "heading": "Our Inclusion Pillars",
+        "description": "Frameworks that create lasting cultural change.",
+        "columns": "3",
+        "items": [
+          { "title": "Inclusive Leadership", "description": "Coaching programs that build equitable decision making.", "icon": "\uD83E\uDDD1\u200D\uD83E\uDDB0" },
+          { "title": "Bias-Free Hiring", "description": "Structured processes that remove unconscious bias.", "icon": "\u2696\uFE0F" },
+          { "title": "Belonging Culture", "description": "Employee initiatives that celebrate diverse perspectives.", "icon": "\uD83E\uDD1D" }
+        ]
+      }
+    },
+    {
+      "id": "metrics-di",
+      "type": "Statistics",
+      "props": {
+        "heading": "Impact Metrics",
+        "description": "Measured outcomes from our D&I engagements.",
+        "stats": [
+          { "value": "40%", "label": "Leadership Diversity", "description": "Average increase in diverse leadership hires", "icon": "\uD83C\uDF0D" },
+          { "value": "3x", "label": "Retention", "description": "Higher retention for inclusive cultures", "icon": "\uD83D\uDCC8" },
+          { "value": "25", "label": "Countries", "description": "Global D&I projects delivered", "icon": "\uD83C\uDF10" }
+        ],
+        "backgroundType": "light"
+      }
+    },
+    {
       "id": "final-cta",
       "type": "CTA",
       "props": {

--- a/apps/website/src/content/pages/industries.json
+++ b/apps/website/src/content/pages/industries.json
@@ -23,6 +23,36 @@
       }
     },
     {
+      "id": "industry-grid",
+      "type": "TilesGrid",
+      "props": {
+        "heading": "Sector Coverage",
+        "description": "Specialized expertise across markets.",
+        "columns": "3",
+        "items": [
+          { "title": "Technology", "description": "Software, SaaS and digital platforms.", "icon": "\uD83D\uDCBB" },
+          { "title": "Healthcare", "description": "Hospitals, biotech and life sciences.", "icon": "\uD83E\uDDEA" },
+          { "title": "Financial Services", "description": "Banking, fintech and insurance.", "icon": "\uD83D\uDCB0" },
+          { "title": "Industrial", "description": "Manufacturing and automotive.", "icon": "\uD83D\uDEE0\uFE0F" },
+          { "title": "Consumer & Retail", "description": "Omnichannel and D2C brands.", "icon": "\uD83D\uDED2" },
+          { "title": "Energy", "description": "Traditional and renewable players.", "icon": "\u26A1\uFE0F" }
+        ]
+      }
+    },
+    {
+      "id": "client-logos",
+      "type": "Logos",
+      "props": {
+        "heading": "Trusted by Leading Organizations",
+        "logos": [
+          { "src": "/images/placeholder.svg", "alt": "Client A" },
+          { "src": "/images/placeholder.svg", "alt": "Client B" },
+          { "src": "/images/placeholder.svg", "alt": "Client C" },
+          { "src": "/images/placeholder.svg", "alt": "Client D" }
+        ]
+      }
+    },
+    {
       "id": "final-cta",
       "type": "CTA",
       "props": {

--- a/apps/website/src/content/pages/insights.json
+++ b/apps/website/src/content/pages/insights.json
@@ -23,6 +23,25 @@
       }
     },
     {
+      "id": "insights-preview",
+      "type": "InsightsPreview",
+      "props": {
+        "heading": "Latest Articles",
+        "description": "Research and perspectives from our consultants."
+      }
+    },
+    {
+      "id": "insights-faq",
+      "type": "FAQ",
+      "props": {
+        "heading": "Insights FAQ",
+        "items": [
+          { "question": "How often do you publish new insights?", "answer": "We share fresh perspectives every month across industries and leadership topics." },
+          { "question": "Can I contribute an article?", "answer": "We welcome guest contributions from industry leaders. Contact us with your idea." }
+        ]
+      }
+    },
+    {
       "id": "final-cta",
       "type": "CTA",
       "props": {

--- a/apps/website/src/content/pages/leadership-hiring.json
+++ b/apps/website/src/content/pages/leadership-hiring.json
@@ -23,6 +23,38 @@
       }
     },
     {
+      "id": "process-leadership",
+      "type": "ProcessSteps",
+      "props": {
+        "heading": "Our Leadership Hiring Process",
+        "description": "A proven approach to secure high-impact leaders.",
+        "steps": [
+          { "number": 1, "title": "Role Definition", "description": "We align on capabilities, culture fit and success metrics." },
+          { "number": 2, "title": "Targeted Search", "description": "Deep research and outreach across our extensive network." },
+          { "number": 3, "title": "Rigorous Assessment", "description": "Behavioral interviews and reference checks benchmarked to your needs." },
+          { "number": 4, "title": "Seamless Integration", "description": "Onboarding support ensures leaders hit the ground running." }
+        ]
+      }
+    },
+    {
+      "id": "testimonials-leadership",
+      "type": "Testimonials",
+      "props": {
+        "heading": "What Clients Say",
+        "items": [
+          {
+            "quote": "Networkk helped us secure a visionary VP who has transformed our product strategy.",
+            "author": { "name": "Sanjay Patel", "title": "CEO", "company": "FinTech Corp" }
+          },
+          {
+            "quote": "Their targeted approach delivered outstanding leadership candidates in record time.",
+            "author": { "name": "Meera Joshi", "title": "HR Director", "company": "HealthPlus" }
+          }
+        ],
+        "layout": "carousel"
+      }
+    },
+    {
       "id": "final-cta",
       "type": "CTA",
       "props": {

--- a/apps/website/src/content/pages/our-approach.json
+++ b/apps/website/src/content/pages/our-approach.json
@@ -23,6 +23,31 @@
       }
     },
     {
+      "id": "approach-timeline",
+      "type": "Timeline",
+      "props": {
+        "heading": "How We Work",
+        "items": [
+          { "date": "Phase 1", "title": "Discovery", "description": "Align on goals, culture and role requirements." },
+          { "date": "Phase 2", "title": "Research", "description": "Map the market and identify qualified leaders." },
+          { "date": "Phase 3", "title": "Evaluation", "description": "Assess candidates through structured interviews." },
+          { "date": "Phase 4", "title": "Selection", "description": "Present shortlist and guide final selection." }
+        ]
+      }
+    },
+    {
+      "id": "approach-metrics",
+      "type": "MetricsBand",
+      "props": {
+        "heading": "Proven Results",
+        "items": [
+          { "value": "95%", "label": "Retention after 2 years" },
+          { "value": "30%", "label": "Faster Hiring Cycles" },
+          { "value": "80+", "label": "Searches annually" }
+        ]
+      }
+    },
+    {
       "id": "final-cta",
       "type": "CTA",
       "props": {

--- a/apps/website/src/content/pages/team.json
+++ b/apps/website/src/content/pages/team.json
@@ -210,6 +210,20 @@
       }
     },
     {
+      "id": "team-stats",
+      "type": "Statistics",
+      "props": {
+        "heading": "Team by the Numbers",
+        "stats": [
+          { "value": "12", "label": "Partners", "icon": "\uD83D\uDC65" },
+          { "value": "8", "label": "Countries", "icon": "\uD83C\uDF0E" },
+          { "value": "25+", "label": "Years Avg Experience", "icon": "\uD83C\uDF93" }
+        ],
+        "backgroundType": "light",
+        "theme": "emerald"
+      }
+    },
+    {
       "id": "join-team-cta",
       "type": "CTA",
       "props": {

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -37,7 +37,6 @@ interface NavItem {
   label: string;
   href: string;
   cta?: boolean;
-  children?: Array<{ label: string; href: string }>;
 }
 
 const siteConfig = await getSiteConfig();
@@ -81,24 +80,20 @@ const navItems: NavItem[] = siteConfig.navigation.header;
             <!-- Desktop Navigation -->
             <div class="hidden lg:flex items-center space-x-8">
               {navItems.map((item) => (
-                item.children ? (
-                  <div class="relative group">
-                    <a href={item.href} class="flex items-center space-x-1 text-gray-700 hover:text-blue-600 font-medium transition-colors">
-                      <span>{item.label}</span>
-                      <svg class="w-4 h-4 transition-transform group-hover:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-                      </svg>
-                    </a>
-                    <div class="absolute left-0 mt-2 hidden group-hover:block bg-white border border-gray-100 rounded-lg shadow-lg py-2 min-w-[12rem]">
-                      {item.children.map((child) => (
-                        <a href={child.href} class="block px-4 py-2 text-gray-700 hover:bg-gray-50 hover:text-blue-600 transition-colors">{child.label}</a>
-                      ))}
-                    </div>
-                  </div>
-                ) : item.cta ? (
-                  <a href={item.href} class="bg-blue-600 text-white px-6 py-2.5 rounded-lg hover:bg-blue-700 transition-all duration-200 font-medium shadow-lg hover:shadow-xl hover:-translate-y-0.5">{item.label}</a>
+                item.cta ? (
+                  <a
+                    href={item.href}
+                    class="bg-blue-600 text-white px-6 py-2.5 rounded-lg hover:bg-blue-700 transition-all duration-200 font-medium shadow-lg hover:shadow-xl hover:-translate-y-0.5"
+                  >
+                    {item.label}
+                  </a>
                 ) : (
-                  <a href={item.href} class="text-gray-700 hover:text-blue-600 font-medium transition-colors relative after:absolute after:bottom-0 after:left-0 after:h-0.5 after:w-0 after:bg-blue-600 after:transition-all hover:after:w-full">{item.label}</a>
+                  <a
+                    href={item.href}
+                    class="text-gray-700 hover:text-blue-600 font-medium transition-colors relative after:absolute after:bottom-0 after:left-0 after:h-0.5 after:w-0 after:bg-blue-600 after:transition-all hover:after:w-full"
+                  >
+                    {item.label}
+                  </a>
                 )
               ))}
             </div>

--- a/apps/website/src/lib/content/adapter.ts
+++ b/apps/website/src/lib/content/adapter.ts
@@ -88,29 +88,18 @@ export async function getSiteConfig() {
     favicon: '/favicon.svg',
     navigation: {
       header: [
-        {
-          label: 'Services',
-          href: '/services',
-          children: [
-            { label: 'Executive Search', href: '/executive-search' },
-            { label: 'Leadership Hiring', href: '/leadership-hiring' },
-            { label: 'Talent Advisory', href: '/talent-advisory' },
-            { label: 'D&I Consulting', href: '/diversity-inclusion' },
-            { label: 'Career Transition', href: '/career-transition' }
-          ]
-        },
+        { label: 'Services', href: '/services' },
+        { label: 'Executive Search', href: '/executive-search' },
+        { label: 'Leadership Hiring', href: '/leadership-hiring' },
+        { label: 'Talent Advisory', href: '/talent-advisory' },
+        { label: 'D&I Consulting', href: '/diversity-inclusion' },
+        { label: 'Career Transition', href: '/career-transition' },
         { label: 'Industries', href: '/industries' },
         { label: 'Insights', href: '/insights' },
-        {
-          label: 'About',
-          href: '/about',
-          children: [
-            { label: 'Our Approach', href: '/our-approach' },
-            { label: 'Case Studies', href: '/case-studies' },
-            { label: 'Team', href: '/team' },
-            { label: 'Careers', href: '/careers' }
-          ]
-        },
+        { label: 'Our Approach', href: '/our-approach' },
+        { label: 'Case Studies', href: '/case-studies' },
+        { label: 'Team', href: '/team' },
+        { label: 'Careers', href: '/careers' },
         { label: 'Contact', href: '/contact', cta: true }
       ],
       footer: [

--- a/apps/website/src/pages/[slug].astro
+++ b/apps/website/src/pages/[slug].astro
@@ -44,5 +44,5 @@ if (!page) {
 }
 ---
 
-<PageLayout page={page} theme="emerald" />
+<PageLayout page={page} theme="default" />
 


### PR DESCRIPTION
## Summary
- flatten navigation to remove dropdown submenus
- unify footer styling across dynamic pages
- add unique content sections to leadership, inclusion, industry, insights, approach, case study, team, and career pages

## Testing
- `npm test` *(fails: Missing script "test" in workspaces)*
- `npm run lint` *(fails: ESLint config not found)*
- `npm run type-check` *(fails: tsc --noEmit error in workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_68a33bc29b548331ad03b90b27a51e9b