### PR TITLE
feat: add design tokens and SEO shell

### DIFF
--- a/apps/website/src/components/seo/SEO.astro
+++ b/apps/website/src/components/seo/SEO.astro
@@ -19,6 +19,21 @@ const {
   titleTemplate = '%s — Networkk'
 } = Astro.props;
 
+if (title.length > 60) {
+  console.warn(`SEO title exceeds 60 characters (${title.length}): ${title}`);
+}
+
+if (description.length < 120 || description.length > 160) {
+  console.warn(`SEO description should be between 120-160 characters (${description.length}).`);
+}
+
+let canonicalUrl;
+try {
+  canonicalUrl = new URL(canonical);
+} catch (e) {
+  throw new Error(`Canonical URL must be absolute: ${canonical}`);
+}
+
 const finalTitle = titleTemplate.replace('%s', title);
 const robotsContent = noindex ? 'noindex,follow' : 'index,follow';
 ---
@@ -27,7 +42,7 @@ const robotsContent = noindex ? 'noindex,follow' : 'index,follow';
 <title>{finalTitle}</title>
 <meta name="description" content={description} />
 <meta name="robots" content={robotsContent} />
-<link rel="canonical" href={canonical} />
+<link rel="canonical" href={canonicalUrl.href} />
 
 <!-- Keywords if provided -->
 {keywords && keywords.length > 0 && (
@@ -38,7 +53,7 @@ const robotsContent = noindex ? 'noindex,follow' : 'index,follow';
 <meta property="og:title" content={finalTitle} />
 <meta property="og:description" content={description} />
 <meta property="og:type" content="website" />
-<meta property="og:url" content={canonical} />
+<meta property="og:url" content={canonicalUrl.href} />
 <meta property="og:image" content={image} />
 <meta property="og:site_name" content="Networkk" />
 

--- a/apps/website/src/components/ui/Image.astro
+++ b/apps/website/src/components/ui/Image.astro
@@ -7,6 +7,7 @@ export interface Props {
   class?: string;
   loading?: 'lazy' | 'eager';
   decoding?: 'async' | 'sync' | 'auto';
+  sizes?: string;
 }
 
 const {
@@ -16,16 +17,30 @@ const {
   height,
   class: className = '',
   loading = 'lazy',
-  decoding = 'async'
+  decoding = 'async',
+  sizes
 } = Astro.props;
----
 
-<img
-  src={src}
-  alt={alt}
-  width={width}
-  height={height}
-  loading={loading}
-  decoding={decoding}
-  class={className}
-/>
+if (alt === undefined) {
+  throw new Error('Image alt text is required. Use alt="" for decorative images.');
+}
+
+const base = src.replace(/\.[^/.]+$/, '');
+const avif = `${base}.avif`;
+const webp = `${base}.webp`;
+---
+<picture>
+  <source srcset={avif} type="image/avif" />
+  <source srcset={webp} type="image/webp" />
+  <img
+    src={src}
+    alt={alt}
+    width={width}
+    height={height}
+    loading={loading}
+    decoding={decoding}
+    sizes={sizes}
+    class={className}
+    fetchpriority={loading === 'eager' ? 'high' : undefined}
+  />
+</picture>

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -70,7 +70,7 @@ const navItems: NavItem[] = siteConfig.navigation.header;
         <nav class="container" aria-label="Main navigation">
           <div class="flex items-center justify-between py-4">
             <!-- Logo -->
-            <a href="/" class="flex items-center space-x-3 group">
+            <a href="/" class="flex items-center space-x-3 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-600">
               <div class="relative">
                 <img src="/logo.png" alt="Networkk Logo" class="h-12 w-auto transition-transform group-hover:scale-105" />
                 <div class="absolute inset-0 bg-gradient-to-r from-blue-600/10 to-purple-600/10 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity -z-10"></div>
@@ -83,14 +83,14 @@ const navItems: NavItem[] = siteConfig.navigation.header;
                 item.cta ? (
                   <a
                     href={item.href}
-                    class="bg-blue-600 text-white px-6 py-2.5 rounded-lg hover:bg-blue-700 transition-all duration-200 font-medium shadow-lg hover:shadow-xl hover:-translate-y-0.5"
+                    class="bg-blue-600 text-white px-6 py-2.5 rounded-lg hover:bg-blue-700 transition-all duration-200 font-medium shadow-lg hover:shadow-xl hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-600"
                   >
                     {item.label}
                   </a>
                 ) : (
                   <a
                     href={item.href}
-                    class="text-gray-700 hover:text-blue-600 font-medium transition-colors relative after:absolute after:bottom-0 after:left-0 after:h-0.5 after:w-0 after:bg-blue-600 after:transition-all hover:after:w-full"
+                    class="text-gray-700 hover:text-blue-600 font-medium transition-colors relative after:absolute after:bottom-0 after:left-0 after:h-0.5 after:w-0 after:bg-blue-600 after:transition-all hover:after:w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-600"
                   >
                     {item.label}
                   </a>
@@ -99,7 +99,7 @@ const navItems: NavItem[] = siteConfig.navigation.header;
             </div>
             
             <!-- Mobile Menu Button -->
-            <button class="lg:hidden p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors" aria-label="Toggle mobile menu">
+            <button class="lg:hidden p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-600" aria-label="Toggle mobile menu">
               <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
               </svg>

--- a/apps/website/src/lib/seo/jsonld.ts
+++ b/apps/website/src/lib/seo/jsonld.ts
@@ -1,0 +1,56 @@
+export interface OrganizationOptions {
+  name: string;
+  url: string;
+  logo: string;
+}
+
+export function organization({ name, url, logo }: OrganizationOptions) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name,
+    url,
+    logo,
+  };
+}
+
+export interface WebsiteOptions {
+  name: string;
+  url: string;
+  searchUrl?: string;
+}
+
+export function website({ name, url, searchUrl }: WebsiteOptions) {
+  const data: Record<string, any> = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name,
+    url,
+  };
+  if (searchUrl) {
+    data.potentialAction = {
+      '@type': 'SearchAction',
+      target: `${searchUrl}{search_term_string}`,
+      'query-input': 'required name=search_term_string',
+    };
+  }
+  return data;
+}
+
+export interface BreadcrumbItem {
+  name: string;
+  url: string;
+}
+
+export function breadcrumbList(items: BreadcrumbItem[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}

--- a/apps/website/src/styles/global.css
+++ b/apps/website/src/styles/global.css
@@ -1,3 +1,5 @@
+@import './tokens.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -7,51 +9,81 @@
     font-family: 'Inter', sans-serif;
     scroll-behavior: smooth;
   }
-  
+
   body {
     @apply bg-white text-gray-900 antialiased;
+    font-size: var(--fs-base);
   }
-  
-  h1, h2, h3, h4, h5, h6 {
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     @apply font-semibold text-gray-900;
     font-family: 'Inter', sans-serif;
   }
-  
+
   h1 {
-    @apply text-4xl md:text-5xl lg:text-6xl leading-tight;
+    font-size: var(--fs-5xl);
+    line-height: 1.1;
   }
-  
+
   h2 {
-    @apply text-3xl md:text-4xl lg:text-5xl leading-tight;
+    font-size: var(--fs-4xl);
+    line-height: 1.15;
   }
-  
+
   h3 {
-    @apply text-2xl md:text-3xl leading-tight;
+    font-size: var(--fs-3xl);
+    line-height: 1.2;
   }
-  
+
   h4 {
-    @apply text-xl md:text-2xl leading-tight;
+    font-size: var(--fs-2xl);
+    line-height: 1.3;
   }
-  
+
   h5 {
-    @apply text-lg md:text-xl leading-tight;
+    font-size: var(--fs-xl);
+    line-height: 1.35;
   }
-  
+
   h6 {
-    @apply text-base md:text-lg leading-tight;
+    font-size: var(--fs-lg);
+    line-height: 1.4;
   }
-  
+
   p {
-    @apply text-gray-600 leading-relaxed;
+    @apply text-gray-600;
+    line-height: 1.7;
   }
-  
+
   a {
     @apply text-primary-600 hover:text-primary-700 transition-colors;
   }
-  
+
+  :focus-visible {
+    outline: 2px solid var(--color-brand-600);
+    outline-offset: 2px;
+  }
+
   /* Skip link for accessibility */
   .skip-link {
-    @apply absolute left-0 top-0 z-50 bg-primary-600 text-white px-4 py-2 transform -translate-y-full focus:translate-y-0 transition-transform;
+    position: absolute;
+    left: 0;
+    top: 0;
+    z-index: 50;
+    background: var(--color-brand-600);
+    color: #fff;
+    padding: var(--space-2) var(--space-4);
+    transform: translateY(-100%);
+    transition: transform 0.2s ease;
+  }
+
+  .skip-link:focus {
+    transform: translateY(0);
   }
 }
 
@@ -70,10 +102,6 @@
   
   .btn-outline {
     @apply border-primary-600 text-primary-600 hover:bg-primary-600 hover:text-white focus:ring-primary-500;
-  }
-  
-  .container {
-    @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
   }
   
   .section {

--- a/apps/website/src/styles/tokens.css
+++ b/apps/website/src/styles/tokens.css
@@ -1,0 +1,60 @@
+:root {
+  /* Spacing scale */
+  --space-0: 0;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+  --space-24: 6rem;
+  --space-32: 8rem;
+
+  /* Fluid type scale */
+  --fs-sm: clamp(0.875rem, 0.84rem + 0.2vw, 0.95rem);
+  --fs-base: clamp(1rem, 0.96rem + 0.25vw, 1.125rem);
+  --fs-lg: clamp(1.125rem, 1.08rem + 0.35vw, 1.25rem);
+  --fs-xl: clamp(1.25rem, 1.2rem + 0.5vw, 1.5rem);
+  --fs-2xl: clamp(1.5rem, 1.4rem + 0.8vw, 1.875rem);
+  --fs-3xl: clamp(1.875rem, 1.7rem + 1vw, 2.25rem);
+  --fs-4xl: clamp(2.25rem, 2rem + 1.5vw, 3rem);
+  --fs-5xl: clamp(3rem, 2.5rem + 2vw, 4rem);
+
+  /* Brand palette */
+  --color-brand-50: #eff6ff;
+  --color-brand-100: #dbeafe;
+  --color-brand-200: #bfdbfe;
+  --color-brand-300: #93c5fd;
+  --color-brand-400: #60a5fa;
+  --color-brand-500: #3b82f6;
+  --color-brand-600: #2563eb;
+  --color-brand-700: #1d4ed8;
+  --color-brand-800: #1e40af;
+  --color-brand-900: #1e3a8a;
+
+  /* Neutral palette */
+  --color-neutral-50: #f9fafb;
+  --color-neutral-100: #f3f4f6;
+  --color-neutral-200: #e5e7eb;
+  --color-neutral-300: #d1d5db;
+  --color-neutral-400: #9ca3af;
+  --color-neutral-500: #6b7280;
+  --color-neutral-600: #4b5563;
+  --color-neutral-700: #374151;
+  --color-neutral-800: #1f2937;
+  --color-neutral-900: #111827;
+
+  /* Radii */
+  --radius-sm: 0.125rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+  --radius-full: 9999px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
+  --shadow-lg: 0 10px 15px rgba(0,0,0,0.15);
+}

--- a/apps/website/tailwind.config.mjs
+++ b/apps/website/tailwind.config.mjs
@@ -2,6 +2,17 @@
 export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
+    container: {
+      center: true,
+      padding: '1rem',
+      screens: {
+        sm: '640px',
+        md: '768px',
+        lg: '1024px',
+        xl: '1280px',
+        '2xl': '1440px',
+      },
+    },
     extend: {
       colors: {
         primary: {
@@ -34,6 +45,30 @@ export default {
       fontFamily: {
         sans: ['Inter', 'sans-serif'],
         serif: ['Merriweather', 'serif'],
+      },
+      spacing: {
+        1: 'var(--space-1)',
+        2: 'var(--space-2)',
+        3: 'var(--space-3)',
+        4: 'var(--space-4)',
+        6: 'var(--space-6)',
+        8: 'var(--space-8)',
+        12: 'var(--space-12)',
+        16: 'var(--space-16)',
+        24: 'var(--space-24)',
+        32: 'var(--space-32)',
+      },
+      borderRadius: {
+        sm: 'var(--radius-sm)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+        xl: 'var(--radius-xl)',
+        full: 'var(--radius-full)',
+      },
+      boxShadow: {
+        sm: 'var(--shadow-sm)',
+        DEFAULT: 'var(--shadow-md)',
+        lg: 'var(--shadow-lg)',
       },
       typography: {
         DEFAULT: {

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,63 @@
+# Design System
+
+## Tokens
+
+### Spacing Scale
+| Token | Value |
+|-------|-------|
+| --space-1 | 0.25rem |
+| --space-2 | 0.5rem |
+| --space-3 | 0.75rem |
+| --space-4 | 1rem |
+| --space-6 | 1.5rem |
+| --space-8 | 2rem |
+| --space-12 | 3rem |
+| --space-16 | 4rem |
+| --space-24 | 6rem |
+| --space-32 | 8rem |
+
+### Fluid Type Scale
+| Token | Example |
+|-------|---------|
+| --fs-sm | clamp(0.875rem, 0.84rem + 0.2vw, 0.95rem) |
+| --fs-base | clamp(1rem, 0.96rem + 0.25vw, 1.125rem) |
+| --fs-lg | clamp(1.125rem, 1.08rem + 0.35vw, 1.25rem) |
+| --fs-xl | clamp(1.25rem, 1.2rem + 0.5vw, 1.5rem) |
+| --fs-2xl | clamp(1.5rem, 1.4rem + 0.8vw, 1.875rem) |
+| --fs-3xl | clamp(1.875rem, 1.7rem + 1vw, 2.25rem) |
+| --fs-4xl | clamp(2.25rem, 2rem + 1.5vw, 3rem) |
+| --fs-5xl | clamp(3rem, 2.5rem + 2vw, 4rem) |
+
+### Color Palette
+Brand colors and neutral grayscale tokens are defined in `src/styles/tokens.css` and mapped in Tailwind config.
+
+### Radii
+`--radius-sm`, `--radius-md`, `--radius-lg`, `--radius-xl`, `--radius-full`
+
+### Shadows
+`--shadow-sm`, `--shadow-md`, `--shadow-lg`
+
+## Grid & Layout
+- 12‑column responsive grid
+- Tailwind `container` centered with breakpoints: sm 640px, md 768px, lg 1024px, xl 1280px, 2xl 1440px
+- Global layout: header/nav, main, footer, skip link, and focus ring styles
+
+## Components
+- `SEO.astro` – meta tags with OpenGraph and Twitter
+- `JsonLd.astro` – renders structured data blocks
+- `Image.astro` – AVIF/WebP sources, alt enforcement, LCP priority
+- `Footer.astro`, `Button.astro`, `Heading.astro`
+- Layout shell: `BaseLayout.astro`
+
+## Page Skeleton
+```
+<html>
+  <head>…SEO…</head>
+  <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+    <header>…nav…</header>
+    <main id="main">…page blocks…</main>
+    <footer>…</footer>
+  </body>
+</html>
+```

--- a/docs/seo-checklist.md
+++ b/docs/seo-checklist.md
@@ -1,0 +1,12 @@
+# Definition of SEO Done (DSD)
+
+- [ ] One `<h1>` per page with logical `<h2>` sections
+- [ ] Title ≤ 60 characters and descriptive
+- [ ] Meta description 120–160 characters
+- [ ] Absolute canonical URL
+- [ ] OpenGraph and Twitter card tags
+- [ ] JSON-LD for Organization, Website, and BreadcrumbList as needed
+- [ ] Images use AVIF/WebP sources and include `alt` text (empty if decorative)
+- [ ] Responsive images with `loading` and `fetchpriority` for LCP elements
+- [ ] Skip link and focus-visible styles present
+- [ ] Page passes lint and type-check scripts


### PR DESCRIPTION
## Summary
- add global design tokens for spacing, typography, color, radii, and shadows
- enforce SEO standards with canonical validation and structured-data helpers
- document design system and provide SEO definition of done

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run type-check` *(fails: tsc build canceled in workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_68a34ae681d88331802821e6a690d853