### PR TITLE
Add industry pages and populate insights preview

### DIFF
--- a/apps/website/src/content/insights/cxo-trends-2025.json
+++ b/apps/website/src/content/insights/cxo-trends-2025.json
@@ -1,0 +1,17 @@
+{
+  "slug": "cxo-trends-2025",
+  "title": "CXO Hiring Trends for 2025",
+  "excerpt": "Key trends shaping executive recruitment in the coming year.",
+  "content": "Full article coming soon.",
+  "image": "/images/insight-cxo-trends.avif",
+  "seo": {
+    "title": "CXO Hiring Trends for 2025 - Networkk",
+    "description": "Key trends shaping executive recruitment in 2025.",
+    "canonical": "https://networkk.com/insights/cxo-trends-2025/",
+    "noindex": false,
+    "keywords": ["cxo", "executive search", "trends"]
+  },
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}

--- a/apps/website/src/content/insights/diversity-hiring-strategies.json
+++ b/apps/website/src/content/insights/diversity-hiring-strategies.json
@@ -1,0 +1,17 @@
+{
+  "slug": "diversity-hiring-strategies",
+  "title": "Diversity Hiring Strategies",
+  "excerpt": "Building inclusive leadership teams with purpose.",
+  "content": "Full article coming soon.",
+  "image": "/images/insight-diversity-hiring.avif",
+  "seo": {
+    "title": "Diversity Hiring Strategies - Networkk",
+    "description": "Building inclusive leadership teams with purpose.",
+    "canonical": "https://networkk.com/insights/diversity-hiring-strategies/",
+    "noindex": false,
+    "keywords": ["diversity", "inclusion", "leadership"]
+  },
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}

--- a/apps/website/src/content/insights/resilient-teams-leadership.json
+++ b/apps/website/src/content/insights/resilient-teams-leadership.json
@@ -1,0 +1,17 @@
+{
+  "slug": "resilient-teams-leadership",
+  "title": "Building Resilient Leadership Teams",
+  "excerpt": "How leaders can foster resilience in uncertain times.",
+  "content": "Full article coming soon.",
+  "image": "/images/insight-resilient-teams.avif",
+  "seo": {
+    "title": "Building Resilient Leadership Teams - Networkk",
+    "description": "How leaders can foster resilience in uncertain times.",
+    "canonical": "https://networkk.com/insights/resilient-teams-leadership/",
+    "noindex": false,
+    "keywords": ["resilience", "leadership", "teams"]
+  },
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}

--- a/apps/website/src/content/pages/home.json
+++ b/apps/website/src/content/pages/home.json
@@ -176,24 +176,7 @@
       "props": {
         "heading": "Insights Preview",
         "description": "Explore our latest thinking on leadership and talent.",
-        "columns": "3",
-        "items": [
-          {
-            "title": "Placeholder Insight One",
-            "description": "Coming soon: in-depth analysis and perspectives.",
-            "href": "/insights/placeholder-one"
-          },
-          {
-            "title": "Placeholder Insight Two",
-            "description": "Insights on executive search and leadership hiring.",
-            "href": "/insights/placeholder-two"
-          },
-          {
-            "title": "Placeholder Insight Three",
-            "description": "Thought leadership articles coming shortly.",
-            "href": "/insights/placeholder-three"
-          }
-        ]
+        "limit": 3
       }
     },
     {

--- a/apps/website/src/content/pages/industries/consumer-retail.json
+++ b/apps/website/src/content/pages/industries/consumer-retail.json
@@ -1,0 +1,29 @@
+{
+  "slug": "industries/consumer-retail",
+  "title": "Consumer & Retail",
+  "status": "published",
+  "seo": {
+    "title": "Consumer & Retail Industry - Networkk",
+    "description": "Executive talent for consumer brands and retailers.",
+    "canonical": "https://networkk.com/industries/consumer-retail/",
+    "noindex": false,
+    "keywords": ["consumer", "retail", "ecommerce"]
+  },
+  "blocks": [
+    {
+      "id": "hero-industry",
+      "type": "Hero",
+      "props": {
+        "title": "Consumer & Retail",
+        "subtitle": "Industry Expertise",
+        "description": "Leaders who navigate evolving consumer expectations.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}

--- a/apps/website/src/content/pages/industries/energy.json
+++ b/apps/website/src/content/pages/industries/energy.json
@@ -1,0 +1,29 @@
+{
+  "slug": "industries/energy",
+  "title": "Energy & Sustainability",
+  "status": "published",
+  "seo": {
+    "title": "Energy & Sustainability Industry - Networkk",
+    "description": "Leaders driving the transition to a sustainable future.",
+    "canonical": "https://networkk.com/industries/energy/",
+    "noindex": false,
+    "keywords": ["energy", "sustainability", "renewables"]
+  },
+  "blocks": [
+    {
+      "id": "hero-industry",
+      "type": "Hero",
+      "props": {
+        "title": "Energy & Sustainability",
+        "subtitle": "Industry Expertise",
+        "description": "Connecting energy pioneers with visionary leadership.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}

--- a/apps/website/src/content/pages/industries/financial-services.json
+++ b/apps/website/src/content/pages/industries/financial-services.json
@@ -1,0 +1,29 @@
+{
+  "slug": "industries/financial-services",
+  "title": "Financial Services",
+  "status": "published",
+  "seo": {
+    "title": "Financial Services Industry - Networkk",
+    "description": "Executive talent for banking, fintech and insurance.",
+    "canonical": "https://networkk.com/industries/financial-services/",
+    "noindex": false,
+    "keywords": ["finance", "fintech", "banking"]
+  },
+  "blocks": [
+    {
+      "id": "hero-industry",
+      "type": "Hero",
+      "props": {
+        "title": "Financial Services",
+        "subtitle": "Industry Expertise",
+        "description": "Leaders who navigate complex financial landscapes.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}

--- a/apps/website/src/content/pages/industries/healthcare.json
+++ b/apps/website/src/content/pages/industries/healthcare.json
@@ -1,0 +1,29 @@
+{
+  "slug": "industries/healthcare",
+  "title": "Healthcare & Life Sciences",
+  "status": "published",
+  "seo": {
+    "title": "Healthcare & Life Sciences Industry - Networkk",
+    "description": "Leadership for pharma, biotech and care providers.",
+    "canonical": "https://networkk.com/industries/healthcare/",
+    "noindex": false,
+    "keywords": ["healthcare", "life sciences", "biotech"]
+  },
+  "blocks": [
+    {
+      "id": "hero-industry",
+      "type": "Hero",
+      "props": {
+        "title": "Healthcare & Life Sciences",
+        "subtitle": "Industry Expertise",
+        "description": "Connecting patient-focused organizations with visionary leaders.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}

--- a/apps/website/src/content/pages/industries/manufacturing.json
+++ b/apps/website/src/content/pages/industries/manufacturing.json
@@ -1,0 +1,29 @@
+{
+  "slug": "industries/manufacturing",
+  "title": "Manufacturing & Industrial",
+  "status": "published",
+  "seo": {
+    "title": "Manufacturing & Industrial Industry - Networkk",
+    "description": "Leadership for advanced manufacturing and industrial firms.",
+    "canonical": "https://networkk.com/industries/manufacturing/",
+    "noindex": false,
+    "keywords": ["manufacturing", "industrial", "industry"]
+  },
+  "blocks": [
+    {
+      "id": "hero-industry",
+      "type": "Hero",
+      "props": {
+        "title": "Manufacturing & Industrial",
+        "subtitle": "Industry Expertise",
+        "description": "Leaders who drive operational excellence and innovation.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}

--- a/apps/website/src/content/pages/industries/technology.json
+++ b/apps/website/src/content/pages/industries/technology.json
@@ -1,0 +1,29 @@
+{
+  "slug": "industries/technology",
+  "title": "Technology & Software",
+  "status": "published",
+  "seo": {
+    "title": "Technology & Software Industry - Networkk",
+    "description": "Talent solutions for software and digital innovators.",
+    "canonical": "https://networkk.com/industries/technology/",
+    "noindex": false,
+    "keywords": ["technology", "software", "digital"]
+  },
+  "blocks": [
+    {
+      "id": "hero-industry",
+      "type": "Hero",
+      "props": {
+        "title": "Technology & Software",
+        "subtitle": "Industry Expertise",
+        "description": "We connect tech innovators with transformative leaders.",
+        "backgroundType": "gradient",
+        "textAlign": "center",
+        "fullHeight": false
+      }
+    }
+  ],
+  "publishedAt": "2025-01-15T10:00:00Z",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-15T10:00:00Z"
+}

--- a/apps/website/src/pages/industries/[industry].astro
+++ b/apps/website/src/pages/industries/[industry].astro
@@ -1,0 +1,29 @@
+---
+import PageLayout from '../../layouts/PageLayout.astro';
+import { loadPageBySlug } from '../../lib/content/adapter';
+
+export async function getStaticPaths() {
+  const modules = import.meta.glob('../../content/pages/industries/*.json', { eager: true });
+  return Object.entries(modules)
+    .map(([filePath, module]) => {
+      const industry = filePath
+        .replace('../../content/pages/industries/', '')
+        .replace('.json', '');
+      const status = (module as any).status || 'published';
+      if (status !== 'published') return null;
+      return { params: { industry } };
+    })
+    .filter(Boolean);
+}
+
+const industry = Astro.params.industry as string;
+const page = await loadPageBySlug(`industries/${industry}`);
+
+if (!page) {
+  return new Response(null, {
+    status: 404,
+    statusText: 'Page not found'
+  });
+}
+---
+<PageLayout page={page} theme="default" />


### PR DESCRIPTION
## Summary
- Add dynamic routing for industry pages and provide content for each sector
- Populate homepage insights preview with real insight data
- Simplify home content to use automatic insight loading

## Testing
- `npm test` *(fails: Missing script "test" in workspace website and packages)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3589045c483319ea211cb7e18d148