### PR TITLE
fix: expand consumer retail SEO description

### DIFF
--- a/apps/website/src/content/pages/industries/consumer-retail.json
+++ b/apps/website/src/content/pages/industries/consumer-retail.json
@@ -4,7 +4,7 @@
   "status": "published",
   "seo": {
     "title": "Consumer & Retail Industry - Networkk",
-    "description": "Executive talent for consumer brands and retailers.",
+    "description": "Executive talent for consumer brands and retailers, connecting leaders who drive omnichannel growth, digital innovation, and memorable customer experiences.",
     "canonical": "https://networkk.com/industries/consumer-retail/",
     "noindex": false,
     "keywords": ["consumer", "retail", "ecommerce"]


### PR DESCRIPTION
## Summary
- expand consumer & retail SEO description to required length

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run type-check` *(fails: src/pages/insights/[slug].astro: Type 'unknown' is not assignable to type 'string | undefined')*
- `npm run build` *(fails: industries/energy SEO description too short)*

------
https://chatgpt.com/codex/tasks/task_e_68a372904d448331a9ea655d37755f62