### PR TITLE
Add industries hub and detail pages with breadcrumbs

### DIFF
--- a/apps/website/src/content/insights/cxo-trends-2025.json
+++ b/apps/website/src/content/insights/cxo-trends-2025.json
@@ -4,13 +4,13 @@
   "excerpt": "Key trends shaping executive recruitment in the coming year.",
   "content": "Full article coming soon.",
   "image": "/images/insight-cxo-trends.avif",
-  "seo": {
-    "title": "CXO Hiring Trends for 2025 - Networkk",
-    "description": "Key trends shaping executive recruitment in 2025.",
-    "canonical": "https://networkk.com/insights/cxo-trends-2025/",
-    "noindex": false,
-    "keywords": ["cxo", "executive search", "trends"]
-  },
+    "seo": {
+      "title": "CXO Hiring Trends for 2025 - Networkk",
+      "description": "Explore emerging priorities in executive recruitment, including digital leadership, distributed workforces and resilient strategy for the year ahead.",
+      "canonical": "https://networkk.com/insights/cxo-trends-2025/",
+      "noindex": false,
+      "keywords": ["cxo", "executive search", "trends"]
+    },
   "publishedAt": "2025-01-15T10:00:00Z",
   "createdAt": "2025-01-15T10:00:00Z",
   "updatedAt": "2025-01-15T10:00:00Z"

--- a/apps/website/src/content/insights/diversity-hiring-strategies.json
+++ b/apps/website/src/content/insights/diversity-hiring-strategies.json
@@ -4,13 +4,13 @@
   "excerpt": "Building inclusive leadership teams with purpose.",
   "content": "Full article coming soon.",
   "image": "/images/insight-diversity-hiring.avif",
-  "seo": {
-    "title": "Diversity Hiring Strategies - Networkk",
-    "description": "Building inclusive leadership teams with purpose.",
-    "canonical": "https://networkk.com/insights/diversity-hiring-strategies/",
-    "noindex": false,
-    "keywords": ["diversity", "inclusion", "leadership"]
-  },
+    "seo": {
+      "title": "Diversity Hiring Strategies - Networkk",
+      "description": "Practical approaches for sourcing, assessing and onboarding diverse executives to build inclusive cultures and stronger decision-making at the top.",
+      "canonical": "https://networkk.com/insights/diversity-hiring-strategies/",
+      "noindex": false,
+      "keywords": ["diversity", "inclusion", "leadership"]
+    },
   "publishedAt": "2025-01-15T10:00:00Z",
   "createdAt": "2025-01-15T10:00:00Z",
   "updatedAt": "2025-01-15T10:00:00Z"

--- a/apps/website/src/content/insights/resilient-teams-leadership.json
+++ b/apps/website/src/content/insights/resilient-teams-leadership.json
@@ -4,13 +4,13 @@
   "excerpt": "How leaders can foster resilience in uncertain times.",
   "content": "Full article coming soon.",
   "image": "/images/insight-resilient-teams.avif",
-  "seo": {
-    "title": "Building Resilient Leadership Teams - Networkk",
-    "description": "How leaders can foster resilience in uncertain times.",
-    "canonical": "https://networkk.com/insights/resilient-teams-leadership/",
-    "noindex": false,
-    "keywords": ["resilience", "leadership", "teams"]
-  },
+    "seo": {
+      "title": "Building Resilient Leadership Teams - Networkk",
+      "description": "Insights on how executives can foster resilience, sustain performance and maintain morale when navigating economic uncertainty and rapid change.",
+      "canonical": "https://networkk.com/insights/resilient-teams-leadership/",
+      "noindex": false,
+      "keywords": ["resilience", "leadership", "teams"]
+    },
   "publishedAt": "2025-01-15T10:00:00Z",
   "createdAt": "2025-01-15T10:00:00Z",
   "updatedAt": "2025-01-15T10:00:00Z"

--- a/apps/website/src/content/pages/industries.json
+++ b/apps/website/src/content/pages/industries.json
@@ -22,50 +22,70 @@
         "fullHeight": false
       }
     },
-    {
-      "id": "industry-grid",
-      "type": "TilesGrid",
-      "props": {
-        "heading": "Sector Coverage",
-        "description": "Specialized expertise across markets.",
-        "columns": "3",
-        "items": [
-          { "title": "Technology", "description": "Software, SaaS and digital platforms.", "icon": "\uD83D\uDCBB" },
-          { "title": "Healthcare", "description": "Hospitals, biotech and life sciences.", "icon": "\uD83E\uDDEA" },
-          { "title": "Financial Services", "description": "Banking, fintech and insurance.", "icon": "\uD83D\uDCB0" },
-          { "title": "Industrial", "description": "Manufacturing and automotive.", "icon": "\uD83D\uDEE0\uFE0F" },
-          { "title": "Consumer & Retail", "description": "Omnichannel and D2C brands.", "icon": "\uD83D\uDED2" },
-          { "title": "Energy", "description": "Traditional and renewable players.", "icon": "\u26A1\uFE0F" }
-        ]
-      }
-    },
-    {
-      "id": "client-logos",
-      "type": "LogosStrip",
-      "props": {
-        "heading": "Trusted by Leading Organizations",
-        "logos": [
-          { "name": "Client A", "image": "/images/placeholder.svg" },
-          { "name": "Client B", "image": "/images/placeholder.svg" },
-          { "name": "Client C", "image": "/images/placeholder.svg" },
-          { "name": "Client D", "image": "/images/placeholder.svg" }
-        ]
-      }
-    },
-    {
-      "id": "final-cta",
-      "type": "CTA",
-      "props": {
-        "heading": "Talk to an Industry Specialist",
-        "description": "Connect with our team for sector-specific insights.",
-        "backgroundType": "gradient",
-        "primaryCta": {
-          "label": "Contact Us",
-          "href": "/contact"
+      {
+        "id": "industry-grid",
+        "type": "TilesGrid",
+        "props": {
+          "heading": "Sector Coverage",
+          "description": "Specialized expertise across markets.",
+          "columns": "3",
+          "items": [
+            { "title": "Technology", "description": "Software, SaaS and digital platforms.", "icon": "\uD83D\uDCBB", "href": "/industries/technology" },
+            { "title": "Healthcare", "description": "Hospitals, biotech and life sciences.", "icon": "\uD83E\uDDEA", "href": "/industries/healthcare" },
+            { "title": "Financial Services", "description": "Banking, fintech and insurance.", "icon": "\uD83D\uDCB0", "href": "/industries/financial-services" },
+            { "title": "Industrial", "description": "Manufacturing and automotive.", "icon": "\uD83D\uDEE0\uFE0F", "href": "/industries/manufacturing" },
+            { "title": "Consumer & Retail", "description": "Omnichannel and D2C brands.", "icon": "\uD83D\uDED2", "href": "/industries/consumer-retail" },
+            { "title": "Energy", "description": "Traditional and renewable players.", "icon": "\u26A1\uFE0F", "href": "/industries/energy" },
+            { "title": "Education", "description": "Higher education and edtech providers.", "icon": "\uD83C\uDF93" },
+            { "title": "Government", "description": "Public sector agencies and PSUs.", "icon": "\uD83C\uDFDB\uFE0F" }
+          ]
+        }
+      },
+      {
+        "id": "industry-highlights",
+        "type": "RichText",
+        "props": {
+          "heading": "Highlights",
+          "content": "<ul><li>Deep sector expertise across 8+ industries</li><li>Specialist consultants with local and global networks</li><li>Proven track record with growth-stage and enterprise clients</li></ul>"
+        }
+      },
+      {
+        "id": "industry-casestudies",
+        "type": "CaseStudy",
+        "props": {
+          "heading": "Representative Success Stories",
+          "studies": [
+            {
+              "title": "Scaling a SaaS Unicorn",
+              "industry": "Technology",
+              "challenge": "Rapid global expansion required seasoned leadership.",
+              "solution": "Placed a VP Engineering with hyper-growth experience.",
+              "results": "Accelerated product delivery and doubled R&D capacity."
+            },
+            {
+              "title": "Digital Transformation in Healthcare",
+              "industry": "Healthcare",
+              "challenge": "Hospital network needed to modernize patient systems.",
+              "solution": "Recruited a CTO to lead multi-year transformation.",
+              "results": "Improved patient engagement and operational efficiency."
+            }
+          ]
+        }
+      },
+      {
+        "id": "final-cta",
+        "type": "CTA",
+        "props": {
+          "heading": "Talk to an Industry Specialist",
+          "description": "Connect with our team for sector-specific insights.",
+          "backgroundType": "gradient",
+          "primaryCta": {
+            "label": "Contact Us",
+            "href": "/contact"
+          }
         }
       }
-    }
-  ],
+    ],
   "publishedAt": "2025-01-15T10:00:00Z",
   "createdAt": "2025-01-15T10:00:00Z",
   "updatedAt": "2025-01-15T10:00:00Z"

--- a/apps/website/src/content/pages/industries/energy.json
+++ b/apps/website/src/content/pages/industries/energy.json
@@ -2,13 +2,13 @@
   "slug": "industries/energy",
   "title": "Energy & Sustainability",
   "status": "published",
-  "seo": {
-    "title": "Energy & Sustainability Industry - Networkk",
-    "description": "Leaders driving the transition to a sustainable future.",
-    "canonical": "https://networkk.com/industries/energy/",
-    "noindex": false,
-    "keywords": ["energy", "sustainability", "renewables"]
-  },
+    "seo": {
+      "title": "Energy & Sustainability Industry - Networkk",
+      "description": "Strategic leadership for oil & gas, utilities and renewable innovators navigating the transition to a sustainable, low-carbon future across global markets.",
+      "canonical": "https://networkk.com/industries/energy/",
+      "noindex": false,
+      "keywords": ["energy", "sustainability", "renewables"]
+    },
   "blocks": [
     {
       "id": "hero-industry",

--- a/apps/website/src/content/pages/industries/financial-services.json
+++ b/apps/website/src/content/pages/industries/financial-services.json
@@ -4,25 +4,80 @@
   "status": "published",
   "seo": {
     "title": "Financial Services Industry - Networkk",
-    "description": "Executive talent for banking, fintech and insurance.",
+      "description": "Leadership recruitment for banks, insurers and fintech startups focused on governance, digital transformation and customer trust across regulated markets.",
     "canonical": "https://networkk.com/industries/financial-services/",
     "noindex": false,
     "keywords": ["finance", "fintech", "banking"]
   },
-  "blocks": [
-    {
-      "id": "hero-industry",
-      "type": "Hero",
-      "props": {
-        "title": "Financial Services",
-        "subtitle": "Industry Expertise",
-        "description": "Leaders who navigate complex financial landscapes.",
-        "backgroundType": "gradient",
-        "textAlign": "center",
-        "fullHeight": false
+    "blocks": [
+      {
+        "id": "hero-industry",
+        "type": "Hero",
+        "props": {
+          "title": "Financial Services",
+          "subtitle": "Industry Expertise",
+          "description": "Leaders who navigate complex financial landscapes.",
+          "backgroundType": "gradient",
+          "textAlign": "center",
+          "fullHeight": false
+        }
+      },
+      {
+        "id": "overview",
+        "type": "RichText",
+        "props": {
+          "heading": "Overview",
+          "content": "<p>We advise banks, insurers and fintechs on building leadership for growth and governance. Through <a href=\"/services/executive-search\">Executive Search</a> and <a href=\"/services/talent-advisory\">Talent Advisory</a>, clients secure leaders who deliver trust and innovation.</p>"
+        }
+      },
+      {
+        "id": "trends",
+        "type": "RichText",
+        "props": {
+          "heading": "Trends",
+          "content": "<ul><li>Fintech disruption challenging legacy models</li><li>Regulatory scrutiny elevating compliance roles</li><li>Digital channels reshaping customer experience</li></ul>"
+        }
+      },
+      {
+        "id": "roles",
+        "type": "TilesGrid",
+        "props": {
+          "heading": "Typical Mandates",
+          "columns": "3",
+          "items": [
+            { "title": "CFO", "description": "Drive financial stewardship and strategy." },
+            { "title": "Chief Risk Officer", "description": "Manage enterprise and regulatory risk." },
+            { "title": "Head of Digital Banking", "description": "Lead fintech partnerships and channels." }
+          ]
+        }
+      },
+      {
+        "id": "case-studies",
+        "type": "CaseStudy",
+        "props": {
+          "heading": "Representative Case Studies",
+          "studies": [
+            {
+              "title": "Fintech Expansion",
+              "industry": "Financial Services",
+              "challenge": "Neobank required experienced compliance leadership for new markets.",
+              "solution": "Secured a Chief Risk Officer with global regulatory expertise.",
+              "results": "Enabled launch in three countries while meeting all regulatory standards."
+            }
+          ]
+        }
+      },
+      {
+        "id": "cta",
+        "type": "CTA",
+        "props": {
+          "heading": "Build Financial Leadership",
+          "description": "Find executives who move capital markets.",
+          "backgroundType": "gradient",
+          "primaryCta": { "label": "Connect With Us", "href": "/contact" }
+        }
       }
-    }
-  ],
+    ],
   "publishedAt": "2025-01-15T10:00:00Z",
   "createdAt": "2025-01-15T10:00:00Z",
   "updatedAt": "2025-01-15T10:00:00Z"

--- a/apps/website/src/content/pages/industries/healthcare.json
+++ b/apps/website/src/content/pages/industries/healthcare.json
@@ -4,25 +4,80 @@
   "status": "published",
   "seo": {
     "title": "Healthcare & Life Sciences Industry - Networkk",
-    "description": "Leadership for pharma, biotech and care providers.",
+      "description": "Executive search and advisory for hospitals, pharma companies and biotech innovators building patient-centric, compliant and growth-ready leadership teams.",
     "canonical": "https://networkk.com/industries/healthcare/",
     "noindex": false,
     "keywords": ["healthcare", "life sciences", "biotech"]
   },
-  "blocks": [
-    {
-      "id": "hero-industry",
-      "type": "Hero",
-      "props": {
-        "title": "Healthcare & Life Sciences",
-        "subtitle": "Industry Expertise",
-        "description": "Connecting patient-focused organizations with visionary leaders.",
-        "backgroundType": "gradient",
-        "textAlign": "center",
-        "fullHeight": false
+    "blocks": [
+      {
+        "id": "hero-industry",
+        "type": "Hero",
+        "props": {
+          "title": "Healthcare & Life Sciences",
+          "subtitle": "Industry Expertise",
+          "description": "Connecting patient-focused organizations with visionary leaders.",
+          "backgroundType": "gradient",
+          "textAlign": "center",
+          "fullHeight": false
+        }
+      },
+      {
+        "id": "overview",
+        "type": "RichText",
+        "props": {
+          "heading": "Overview",
+          "content": "<p>We partner with hospitals, pharma and biotech firms to build leadership that advances patient outcomes. Our <a href=\"/services/talent-advisory\">Talent Advisory</a> and <a href=\"/services/executive-search\">Executive Search</a> solutions address complex regulatory and growth challenges.</p>"
+        }
+      },
+      {
+        "id": "trends",
+        "type": "RichText",
+        "props": {
+          "heading": "Trends",
+          "content": "<ul><li>Shift toward value-based care models</li><li>Biotech innovation accelerating treatment pipelines</li><li>Digital health driving patient engagement</li></ul>"
+        }
+      },
+      {
+        "id": "roles",
+        "type": "TilesGrid",
+        "props": {
+          "heading": "Typical Mandates",
+          "columns": "3",
+          "items": [
+            { "title": "Chief Medical Officer", "description": "Clinical leadership for care delivery." },
+            { "title": "R&D Head", "description": "Advance research and innovation." },
+            { "title": "Regulatory Affairs Director", "description": "Navigate global compliance." }
+          ]
+        }
+      },
+      {
+        "id": "case-studies",
+        "type": "CaseStudy",
+        "props": {
+          "heading": "Representative Case Studies",
+          "studies": [
+            {
+              "title": "Biotech Commercialization",
+              "industry": "Healthcare",
+              "challenge": "Late-stage biotech needed go-to-market leadership.",
+              "solution": "Placed a Chief Commercial Officer with global launch experience.",
+              "results": "Achieved successful FDA approval and international expansion."
+            }
+          ]
+        }
+      },
+      {
+        "id": "cta",
+        "type": "CTA",
+        "props": {
+          "heading": "Hire Healthcare Leaders",
+          "description": "Partner with us to build patient-first teams.",
+          "backgroundType": "gradient",
+          "primaryCta": { "label": "Request Talent", "href": "/contact" }
+        }
       }
-    }
-  ],
+    ],
   "publishedAt": "2025-01-15T10:00:00Z",
   "createdAt": "2025-01-15T10:00:00Z",
   "updatedAt": "2025-01-15T10:00:00Z"

--- a/apps/website/src/content/pages/industries/manufacturing.json
+++ b/apps/website/src/content/pages/industries/manufacturing.json
@@ -2,13 +2,13 @@
   "slug": "industries/manufacturing",
   "title": "Manufacturing & Industrial",
   "status": "published",
-  "seo": {
-    "title": "Manufacturing & Industrial Industry - Networkk",
-    "description": "Leadership for advanced manufacturing and industrial firms.",
-    "canonical": "https://networkk.com/industries/manufacturing/",
-    "noindex": false,
-    "keywords": ["manufacturing", "industrial", "industry"]
-  },
+    "seo": {
+      "title": "Manufacturing & Industrial Industry - Networkk",
+      "description": "Executive talent for manufacturers and industrial enterprises optimizing supply chains, embracing automation and driving operational excellence.",
+      "canonical": "https://networkk.com/industries/manufacturing/",
+      "noindex": false,
+      "keywords": ["manufacturing", "industrial", "industry"]
+    },
   "blocks": [
     {
       "id": "hero-industry",

--- a/apps/website/src/content/pages/industries/technology.json
+++ b/apps/website/src/content/pages/industries/technology.json
@@ -4,7 +4,7 @@
   "status": "published",
   "seo": {
     "title": "Technology & Software Industry - Networkk",
-    "description": "Talent solutions for software and digital innovators.",
+      "description": "Executive talent solutions for software developers, SaaS providers and digital innovators seeking experienced leadership to scale products and teams globally.",
     "canonical": "https://networkk.com/industries/technology/",
     "noindex": false,
     "keywords": ["technology", "software", "digital"]
@@ -20,6 +20,61 @@
         "backgroundType": "gradient",
         "textAlign": "center",
         "fullHeight": false
+      }
+    },
+    {
+      "id": "overview",
+      "type": "RichText",
+      "props": {
+        "heading": "Overview",
+        "content": "<p>From early-stage disruptors to global platforms, we help technology companies secure leadership that drives innovation. Our services span <a href=\"/services/executive-search\">Executive Search</a> and <a href=\"/services/leadership-hiring\">Leadership Hiring</a> to build resilient teams.</p>"
+      }
+    },
+    {
+      "id": "trends",
+      "type": "RichText",
+      "props": {
+        "heading": "Trends",
+        "content": "<ul><li>AI and automation reshaping product roadmaps</li><li>Global competition for engineering leadership</li><li>Focus on scalable, secure cloud infrastructure</li></ul>"
+      }
+    },
+    {
+      "id": "roles",
+      "type": "TilesGrid",
+      "props": {
+        "heading": "Typical Mandates",
+        "columns": "3",
+        "items": [
+          { "title": "CTO", "description": "Technology vision and architecture." },
+          { "title": "VP Engineering", "description": "Scale development teams and processes." },
+          { "title": "Product Head", "description": "Lead product strategy and execution." }
+        ]
+      }
+    },
+    {
+      "id": "case-studies",
+      "type": "CaseStudy",
+      "props": {
+        "heading": "Representative Case Studies",
+        "studies": [
+          {
+            "title": "Scaling a SaaS Unicorn",
+            "industry": "Technology",
+            "challenge": "Series D startup needed seasoned leadership to manage hyper-growth.",
+            "solution": "Delivered a VP Engineering with global scaling experience.",
+            "results": "Reduced release cycles and doubled engineering capacity within a year."
+          }
+        ]
+      }
+    },
+    {
+      "id": "cta",
+      "type": "CTA",
+      "props": {
+        "heading": "Need Tech Talent?",
+        "description": "Let's discuss your next strategic hire.",
+        "backgroundType": "gradient",
+        "primaryCta": { "label": "Start a Search", "href": "/contact" }
       }
     }
   ],

--- a/apps/website/src/layouts/PageLayout.astro
+++ b/apps/website/src/layouts/PageLayout.astro
@@ -4,6 +4,7 @@ import Heading from '../components/ui/Heading.astro';
 import BlockRenderer from '../components/blocks/BlockRenderer.astro';
 import JsonLd from '../components/seo/JsonLd.astro';
 import { createOrganizationSchema, createWebsiteSchema, createBreadcrumbSchema } from '../lib/seo';
+import { loadPageBySlug } from '../lib/content/adapter';
 
 export interface Props {
   page: {
@@ -48,6 +49,16 @@ const breadcrumbItems = [
 ];
 
 if (page.slug !== 'home') {
+  const segments = page.slug.split('/');
+  let accumulated = '';
+  for (let i = 0; i < segments.length - 1; i++) {
+    accumulated += (i > 0 ? '/' : '') + segments[i];
+    const parent = await loadPageBySlug(accumulated);
+    if (parent) {
+      breadcrumbItems.push({ name: parent.title, url: parent.seo.canonical });
+    }
+  }
+
   breadcrumbItems.push({
     name: page.title,
     url: page.seo.canonical


### PR DESCRIPTION
## Summary
- Build industries hub page with sector grid, highlights, case studies and CTA
- Add detailed pages for technology, healthcare and financial services with trends, mandates and case studies
- Generate hierarchical breadcrumb JSON-LD in PageLayout
- Extend SEO descriptions to satisfy content validation

## Testing
- `npm run lint --workspace=website` *(fails: ESLint couldn't find config)*
- `npm run build --workspace=website` *(fails: Invalid SEO data for page: services/executive-search)*

------
https://chatgpt.com/codex/tasks/task_e_68a374453d9c8331bfac37f2cc72b326